### PR TITLE
Fix problem where on service start the filename is S20metricproxy.pid an...

### DIFF
--- a/metricproxy
+++ b/metricproxy
@@ -15,7 +15,7 @@ configfile="/etc/sfdbconfig.conf"
 logdir="/var/log/sfproxy"
 binary="/opt/sfproxy/bin/metricproxy"
 
-name=$(basename "$0")
+name=$(basename $(readlink -f "$0"))
 pid_file="/var/run/$name.pid"
 stdout_log="/var/log/$name.stdout.log"
 stderr_log="/var/log/$name.stderr.log"


### PR DESCRIPTION
...d subsequent starts look for metricproxy.pid

When a machine starts and service init starts the service it uses the name S20metricproxy.pid. Subsequent runs of metricproxy through 'service metricproxy status' will not find the pid file b/c it is looking for metricproxy.pid. This causes the second to fail to start because of port bind errors. 