### PR TITLE
remove the '-f' from readlink to be compatible across distros

### DIFF
--- a/metricproxy
+++ b/metricproxy
@@ -15,9 +15,7 @@ configfile="/etc/sfdbconfig.conf"
 logdir="/var/log/sfproxy"
 binary="/opt/sfproxy/bin/metricproxy"
 
-# Note: BSD readlink doesn't use the same -f.  For BSD, you can remove the readlink.  See
-#       https://github.com/signalfx/metricproxy/pull/3
-name=$(basename $(readlink -f "$0"))
+name=$(basename $(readlink "$0"))
 pid_file="/var/run/$name.pid"
 stdout_log="/var/log/$name.stdout.log"
 stderr_log="/var/log/$name.stderr.log"


### PR DESCRIPTION
We don't need the canonical path because we only care about the basename. We don't need the '-f' in the readlink command