### PR TITLE
change the init script to not derive the name of the PID file

### DIFF
--- a/metricproxy
+++ b/metricproxy
@@ -15,7 +15,7 @@ configfile="/etc/sfdbconfig.conf"
 logdir="/var/log/sfproxy"
 binary="/opt/sfproxy/bin/metricproxy"
 
-name=$(basename "$(readlink "$0")")
+name="metricproxy"
 pid_file="/var/run/$name.pid"
 stdout_log="/var/log/$name.stdout.log"
 stderr_log="/var/log/$name.stderr.log"


### PR DESCRIPTION
turns out that readlink will return nothing if the file is *not* a link. This causes problems to say the least. 