### PR TITLE
Add Delimiter based Deconstructor for carbon metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Placeholder changes in the oldest release exist only to document which
 subsections are relevant.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.8.0] - 2015-10-12
+
+### Added
+
+- Support delimiter based metric deconstructor usable for dimensionalizing of
+  graphite metrics
+
 ## [0.7.0] - 2015-07-13
 
 ### Added

--- a/config/config.go
+++ b/config/config.go
@@ -34,17 +34,18 @@ type ForwardTo struct {
 
 // ListenFrom configures how we listen for datapoints to forward
 type ListenFrom struct {
-	Type                       string
-	ListenAddr                 *string
-	MetricDeconstructor        *string
-	MetricDeconstructorOptions *string
-	Timeout                    *string
-	Name                       *string
-	ListenPath                 *string
-	JSONEngine                 *string
-	Encrypted                  *bool
-	TimeoutDuration            *time.Duration `json:"-"`
-	ServerAcceptDeadline       *time.Duration `json:"-"`
+	Type                           string
+	ListenAddr                     *string
+	MetricDeconstructor            *string
+	MetricDeconstructorOptions     *string
+	MetricDeconstructorOptionsJSON map[string]interface{}
+	Timeout                        *string
+	Name                           *string
+	ListenPath                     *string
+	JSONEngine                     *string
+	Encrypted                      *bool
+	TimeoutDuration                *time.Duration `json:"-"`
+	ServerAcceptDeadline           *time.Duration `json:"-"`
 }
 
 func (listenFrom *ListenFrom) String() string {

--- a/protocol/carbon/carbonlistener.go
+++ b/protocol/carbon/carbonlistener.go
@@ -171,12 +171,12 @@ func ListenerLoader(ctx context.Context, sink dpsink.Sink, listenFrom *config.Li
 	//  *listenFrom.Name
 	return NewListener(
 		ctx, sink, conf, *listenFrom.ListenAddr,
-		*listenFrom.MetricDeconstructor, *listenFrom.MetricDeconstructorOptions)
+		*listenFrom.MetricDeconstructor, *listenFrom.MetricDeconstructorOptions, listenFrom.MetricDeconstructorOptionsJSON)
 }
 
 // NewListener creates a new listener for carbon datapoints
 func NewListener(ctx context.Context, sink dpsink.Sink, conf listenerConfig, listenAddr string,
-	metricDeconstructor string, metricDeconstructorOptions string) (*Listener, error) {
+	metricDeconstructor string, metricDeconstructorOptions string, metricDeconstructorJSON map[string]interface{}) (*Listener, error) {
 	psocket, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		return nil, err
@@ -184,7 +184,10 @@ func NewListener(ctx context.Context, sink dpsink.Sink, conf listenerConfig, lis
 
 	deconstructor, err := metricdeconstructor.Load(metricDeconstructor, metricDeconstructorOptions)
 	if err != nil {
-		return nil, err
+		deconstructor, err = metricdeconstructor.LoadJSON(metricDeconstructor, metricDeconstructorJSON)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	counter := &dpsink.Counter{}

--- a/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor.go
+++ b/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor.go
@@ -1,0 +1,374 @@
+package metricdeconstructor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"errors"
+
+	"github.com/signalfx/golib/datapoint"
+)
+
+func split(path string, delimiter string) []string {
+	return strings.Split(path, delimiter)
+}
+
+type typer struct {
+	MetricTypeString string `json:"MetricType"`
+	MetricType       *datapoint.MetricType
+	P                *configurableDelimiterMetricDeconstructor
+}
+
+func (t *typer) verifyType() error {
+	if t.MetricTypeString != "" {
+		metricType, ok := nameToType[t.MetricTypeString]
+		if !ok {
+			return fmt.Errorf("cannot parse configured MetricType of %s", t.MetricTypeString)
+		}
+		t.MetricType = &metricType
+	}
+	return nil
+}
+
+type typeRule struct {
+	typer
+	StartsWith string `json:"StartsWith"`
+	EndsWith   string `json:"EndsWith"`
+}
+
+var errTypeRuleNotDefined = errors.New("a TypeRule is defined without a type")
+var errTypeRuleIllDefined = errors.New("a TypeRule is defined with neither StartsWith or EndsWith")
+
+func (t *typeRule) verify() error {
+	err := t.verifyType()
+	if err != nil {
+		return err
+	}
+	if t.MetricType == nil {
+		return errTypeRuleNotDefined
+	}
+	if t.StartsWith == "" && t.EndsWith == "" {
+		return errTypeRuleIllDefined
+	}
+	return nil
+}
+
+func (t *typeRule) extractType(line *string) *datapoint.MetricType {
+	if (t.StartsWith != "" && strings.HasPrefix(*line, t.StartsWith) || t.StartsWith == "") && (t.EndsWith != "" && strings.HasSuffix(*line, t.EndsWith) || t.EndsWith == "") {
+		return t.MetricType
+
+	}
+	return nil
+}
+
+type configurableDelimiterMetricRule struct {
+	typer
+	MetricPath           string            `json:"MetricPath"`
+	DimensionsMap        string            `json:"DimensionsMap"`
+	MetricName           string            `json:"MetricName"`
+	AdditionalDimensions map[string]string `json:"Dimensions"`
+	MetricPathParts      []matcher
+	DimensionsPathParts  []string
+	UseCount             int64
+}
+
+type matcher interface {
+	match(string) bool
+}
+
+type starMatcher struct{}
+
+// startMatcher always matches
+func (s *starMatcher) match(term string) bool {
+	return true
+}
+
+type idMatcher struct {
+	Term string
+}
+
+// idMatcher matches iff the term is exactly equal to s.Term
+func (s *idMatcher) match(term string) bool {
+	if s.Term == term {
+		return true
+	}
+	return false
+}
+
+type notMatcher struct {
+	Term string
+}
+
+// notMatcher matches iff the term is not exactly equal to s.Term
+func (s *notMatcher) match(term string) bool {
+	if s.Term != term {
+		return true
+	}
+	return false
+}
+
+type termMatcher struct {
+	TermOptions []matcher
+}
+
+// termMatcher matches if one of the terms within it matches
+func (t *termMatcher) match(term string) bool {
+	for _, o := range t.TermOptions {
+		if o.match(term) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *configurableDelimiterMetricRule) newMatchTerm(term string) matcher {
+	if term == m.P.Globbing {
+		return &starMatcher{}
+	}
+	terms := split(term, m.P.OrDelimiter)
+	termMatchers := make([]matcher, len(terms))
+	for i, o := range terms {
+		if len(o) > 0 && o[:1] == m.P.NotDelimiter {
+			termMatchers[i] = &notMatcher{o[1:]}
+		} else {
+			termMatchers[i] = &idMatcher{o}
+		}
+	}
+	return &termMatcher{TermOptions: termMatchers}
+}
+
+func (m *configurableDelimiterMetricRule) parseMetricPath() {
+	if m.MetricPath == "" {
+		m.MetricPathParts = make([]matcher, 0)
+	} else {
+		terms := split(m.MetricPath, m.P.Delimiter)
+		m.MetricPathParts = make([]matcher, len(terms))
+		for i, term := range terms {
+			m.MetricPathParts[i] = m.newMatchTerm(term)
+		}
+	}
+	for i := len(m.MetricPathParts); i < len(m.DimensionsPathParts); i++ {
+		m.MetricPathParts = append(m.MetricPathParts, &starMatcher{})
+	}
+}
+
+func (m *configurableDelimiterMetricRule) String() string {
+	return fmt.Sprintf("MetricsPath: %s\nDimensionsMap: %s\nUseCount: %d\nAdditionalDimensions %v\nMetricPathParts %v\nDimensionsPathParts %v\n", m.MetricPath, m.DimensionsMap, m.UseCount, m.AdditionalDimensions, m.MetricPathParts, m.DimensionsPathParts)
+}
+
+func (m *configurableDelimiterMetricRule) verify() error {
+	m.DimensionsPathParts = split(m.DimensionsMap, m.P.Delimiter)
+	m.parseMetricPath()
+	if len(m.MetricPathParts) != len(m.DimensionsPathParts) {
+		return fmt.Errorf("the MetricPath %s has %d terms but DimensionsMap %s has %d", m.MetricPath, len(m.MetricPathParts), m.DimensionsMap, len(m.DimensionsPathParts))
+	}
+	found := false
+	for _, piece := range m.DimensionsPathParts {
+		if piece == m.P.MetricIdentifier {
+			found = true
+			break
+		}
+	}
+	if !found && m.MetricName == "" {
+		return fmt.Errorf("the DimensionsMap does not have a metric specified; use %s to specify the metric name override MetricName", m.P.MetricIdentifier)
+	}
+	err := m.verifyType()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *configurableDelimiterMetricRule) extract(metricPieces []string) ([]string, map[string][]string) {
+	dims := make(map[string][]string)
+	metric := make([]string, 0, 1)
+
+	if m.MetricName != "" {
+		metric = append(metric, m.MetricName)
+	}
+
+	for i := 0; i < len(metricPieces); i++ {
+		if m.MetricPathParts[i].match(metricPieces[i]) {
+			if m.DimensionsPathParts[i] == m.P.Ignore {
+				continue
+			} else if m.DimensionsPathParts[i] == m.P.MetricIdentifier {
+				metric = append(metric, metricPieces[i])
+			} else {
+				_, ok := dims[m.DimensionsPathParts[i]]
+				if !ok {
+					dims[m.DimensionsPathParts[i]] = make([]string, 0, 1)
+				}
+				dims[m.DimensionsPathParts[i]] = append(dims[m.DimensionsPathParts[i]], metricPieces[i])
+			}
+		} else {
+			return nil, nil
+		}
+	}
+	return metric, dims
+}
+
+func (m *configurableDelimiterMetricRule) extractDimensions(metricPieces []string) (string, map[string]string) {
+	metric, dims := m.extract(metricPieces)
+	dimensions := make(map[string]string)
+	for k, v := range dims {
+		dimensions[k] = strings.Join(v, m.P.Delimiter)
+	}
+	for k, v := range m.AdditionalDimensions {
+		_, ok := dimensions[k]
+		if !ok {
+			dimensions[k] = v
+		}
+	}
+	// precedence is for additional dimensions on the rule over the whole deconstructor
+	for k, v := range m.P.AdditionalDimensions {
+		_, ok := dimensions[k]
+		if !ok {
+			dimensions[k] = v
+		}
+	}
+	m.UseCount++
+	return strings.Join(metric, m.P.Delimiter), dimensions
+}
+
+type configurableDelimiterMetricDeconstructor struct {
+	OrDelimiter                 string                             `json:"OrDelimiter"`
+	Delimiter                   string                             `json:"Delimiter"`
+	Globbing                    string                             `json:"Globbing"`
+	Ignore                      string                             `json:"IgnoreDimension"`
+	NotDelimiter                string                             `json:"NotDelimiter"`
+	MetricIdentifier            string                             `json:"MetricIdentifier"`
+	DefaultMetricType           datapoint.MetricType               `json:"DefaultMetricType"`
+	MetricRules                 []*configurableDelimiterMetricRule `json:"MetricRules"`
+	FallBackDeconstructorName   string                             `json:"FallbackDeconstructor"`
+	FallBackDeconstructorConfig string                             `json:"FallbackDeconstructorConfig"`
+	AdditionalDimensions        map[string]string                  `json:"Dimensions"`
+	FallBackDeconstructor       MetricDeconstructor
+	MetricsMap                  map[int][]*configurableDelimiterMetricRule
+	TypeRules                   []*typeRule `json:"TypeRules"`
+}
+
+func (m *configurableDelimiterMetricDeconstructor) split(path string) []string {
+	return split(path, m.Delimiter)
+}
+
+func (m *configurableDelimiterMetricDeconstructor) String() string {
+	return fmt.Sprintf("ConfigurableDelimiterMetricDeconstructor Metric Rules: %v\nType Rules: %v\n", m.MetricRules, m.TypeRules)
+}
+
+func (m *configurableDelimiterMetricDeconstructor) verifyConfig() error {
+	allOptions := []string{m.OrDelimiter, m.Delimiter, m.Globbing, m.Ignore, m.MetricIdentifier, m.NotDelimiter}
+	for i, vi := range allOptions {
+		for j, vj := range allOptions {
+			if i != j && vi == vj {
+				return fmt.Errorf("overridden option cannot be the same as another: %s", vi)
+			}
+		}
+	}
+	return nil
+}
+
+func (m *configurableDelimiterMetricDeconstructor) verify() error {
+	err := m.verifyConfig()
+	if err != nil {
+		return err
+	}
+	m.MetricsMap = make(map[int][]*configurableDelimiterMetricRule)
+	for _, t := range m.TypeRules {
+		t.P = m
+		err := t.verify()
+		if err != nil {
+			return err
+		}
+	}
+	for _, metric := range m.MetricRules {
+		metric.P = m
+		err := metric.verify()
+		if err != nil {
+			return err
+		}
+		length := len(metric.MetricPathParts)
+		maplist, ok := m.MetricsMap[length]
+		if !ok {
+			maplist = make([]*configurableDelimiterMetricRule, 0)
+		}
+		m.MetricsMap[length] = append(maplist, metric)
+	}
+
+	loader, exists := knownLoaders[m.FallBackDeconstructorName]
+
+	if !exists {
+		return fmt.Errorf("unable to load metric deconstructor by the name of %s", m.FallBackDeconstructorName)
+	}
+	decon, err := loader(m.FallBackDeconstructorConfig)
+	if err != nil {
+		return err
+	}
+	m.FallBackDeconstructor = decon
+
+	return nil
+}
+
+func (m *configurableDelimiterMetricDeconstructor) getMetricType(metric *configurableDelimiterMetricRule, line *string) datapoint.MetricType {
+	if metric.MetricType != nil {
+		return *metric.MetricType
+	}
+	for _, t := range m.TypeRules {
+		mt := t.extractType(line)
+		if mt != nil {
+			return *mt
+		}
+	}
+	return datapoint.Gauge
+}
+
+// Parse turns the line into its dimensions, metric type and metric name based on configuration rules defined when constructing the deconstructor
+func (m *configurableDelimiterMetricDeconstructor) Parse(originalMetric string) (string, datapoint.MetricType, map[string]string, error) {
+	metricPieces := m.split(originalMetric)
+	length := len(metricPieces)
+	metrics, ok := m.MetricsMap[length]
+	if !ok {
+		return m.FallBackDeconstructor.Parse(originalMetric)
+	}
+
+	for _, metric := range metrics {
+		metricName, dimensions := metric.extractDimensions(metricPieces)
+		if metricName != "" {
+			return metricName, m.getMetricType(metric, &originalMetric), dimensions, nil
+		}
+	}
+	return m.FallBackDeconstructor.Parse(originalMetric)
+}
+
+func delimiterJSONLoader(config map[string]interface{}) (MetricDeconstructor, error) {
+	var metrics configurableDelimiterMetricDeconstructor
+	// a wee bit of a hack, but at least we know it's valid json and it makes the config easier
+	jsonString, _ := json.Marshal(config)
+	err := json.Unmarshal([]byte(jsonString), &metrics)
+	if err != nil {
+		return nil, err
+	}
+	if metrics.OrDelimiter == "" {
+		metrics.OrDelimiter = "|"
+	}
+	if metrics.NotDelimiter == "" {
+		metrics.NotDelimiter = "!"
+	}
+	if metrics.Delimiter == "" {
+		metrics.Delimiter = "."
+	}
+	if metrics.Globbing == "" {
+		metrics.Globbing = "*"
+	}
+	if metrics.Ignore == "" {
+		metrics.Ignore = "-"
+	}
+	if metrics.MetricIdentifier == "" {
+		metrics.MetricIdentifier = "%"
+	}
+	err = metrics.verify()
+	if err != nil {
+		return nil, err
+	}
+	return &metrics, nil
+}

--- a/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor_test.go
+++ b/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor_test.go
@@ -1,0 +1,493 @@
+package metricdeconstructor
+
+import (
+	"testing"
+
+	"encoding/json"
+	"fmt"
+
+	"github.com/signalfx/golib/datapoint"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+)
+
+var validConfig = `{
+  "TypeRules": [
+    {
+      "StartsWith":"counter",
+      "MetricType": "count"
+    },
+    {
+      "EndsWith":"count",
+      "MetricType": "count"
+    }
+  ],
+  "MetricRules": [
+	{
+	  "MetricPath": "email|mail.account.*.*.*.*.*",
+	  "DimensionsMap": "object.object.-.action.action.%.%",
+	  "MetricType": "count",
+	  "Dimensions": {
+		"key1": "value1",
+		"key2": "value2"
+	  }
+	},
+	{
+	  "DimensionsMap": "service.instance.thang.%",
+	  "MetricName": "thinger"
+	},
+	{
+	  "MetricPath": "cassandra",
+	  "DimensionsMap": "service.occurrence.%"
+	},
+	{
+	  "MetricPath": "!cassandra",
+	  "DimensionsMap": "service.instance.%.%.-"
+	},
+	{
+	  "DimensionsMap": "service.instance.%"
+	}
+  ]
+}`
+
+func getData(t *testing.T, data string) map[string]interface{} {
+	dat := make(map[string]interface{}, 0)
+	err := json.Unmarshal([]byte(data), &dat)
+	assert.NoError(t, err)
+	return dat
+}
+
+func getDeconstructor(t *testing.T) MetricDeconstructor {
+	m, err := delimiterJSONLoader(getData(t, validConfig))
+	assert.NoError(t, err)
+	return m
+}
+
+// this tests many things in one
+// - joined metric names
+// - joined dimensions
+// - extra dimensions
+// - changing metric type from default
+// - ignoring a dimension
+// - test or as well
+func TestParser(t *testing.T) {
+	Convey("Given the valid config", t, func() {
+		m := getDeconstructor(t)
+		Convey("seven term line starting with email.account", func() {
+			metric, metricType, dimensions, err := m.Parse("email.account.welcome_new.click.it-IT.gmail.count")
+			Convey("should parse without error", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("should parse with a joined metricName", func() {
+				So(metric, ShouldEqual, "gmail.count")
+			})
+			Convey("should be a counter", func() {
+				So(metricType, ShouldEqual, datapoint.Count)
+			})
+			dims := map[string]string{"object": "email.account", "action": "click.it-IT", "key1": "value1", "key2": "value2"}
+			Convey("action and object should be joined and supplemental dimensions were added", func() {
+				So(dimensions, ShouldResemble, dims)
+			})
+		})
+		Convey("String should work", func() {
+			s := fmt.Sprintf("%v", m)
+			So(s, ShouldNotBeNil)
+		})
+		Convey("seven term line starting with mail.account", func() {
+			metric, metricType, dimensions, err := m.Parse("mail.account.welcome_new.click.it-IT.mail.count")
+			Convey("should parse without error", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("should parse with a joined metricName", func() {
+				So(metric, ShouldEqual, "mail.count")
+			})
+			Convey("should be a counter", func() {
+				So(metricType, ShouldEqual, datapoint.Count)
+			})
+			dims := map[string]string{"object": "mail.account", "action": "click.it-IT", "key1": "value1", "key2": "value2"}
+			Convey("action and object should be joined and supplemental dimensions were added and some ignored", func() {
+				So(dimensions, ShouldResemble, dims)
+			})
+		})
+		Convey("generic line with three terms", func() {
+			metric, metricType, dimensions, err := m.Parse("gmail.gmail23.invalid_logins")
+			Convey("should parse without error in config not needing a metric_path", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("last field should be metricName", func() {
+				So(metric, ShouldEqual, "invalid_logins")
+			})
+			Convey("should be a gauge", func() {
+				So(metricType, ShouldEqual, datapoint.Gauge)
+			})
+			dims := map[string]string{"service": "gmail", "instance": "gmail23"}
+			Convey("first two fields should be dimensions", func() {
+				So(dimensions, ShouldResemble, dims)
+			})
+		})
+		Convey("line with three terms start with cassandra", func() {
+			metric, metricType, dimensions, err := m.Parse("cassandra.cassandra23.invalid_logins")
+			Convey("should parse without error even though only cassandra is specified", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("last field should be metricName", func() {
+				So(metric, ShouldEqual, "invalid_logins")
+			})
+			Convey("should be a gauge", func() {
+				So(metricType, ShouldEqual, datapoint.Gauge)
+			})
+			dims := map[string]string{"service": "cassandra", "occurrence": "cassandra23"}
+			Convey("first two fields should be dimensions", func() {
+				So(dimensions, ShouldResemble, dims)
+			})
+		})
+		Convey("line with five terms starting with cassandra", func() {
+			metric, metricType, dimensions, err := m.Parse("cassandra.cassandra23.invalid_logins.rate.ignored")
+			Convey("should parse without error", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("should have fallen through to identify graphite deconstructor", func() {
+				So(metric, ShouldEqual, "cassandra.cassandra23.invalid_logins.rate.ignored")
+			})
+			Convey("should be a gauge", func() {
+				So(metricType, ShouldEqual, datapoint.Gauge)
+			})
+			Convey("hould have no dimensions", func() {
+				So(len(dimensions), ShouldEqual, 0)
+			})
+		})
+		Convey("line with five terms not starting with cassandra", func() {
+			metric, metricType, dimensions, err := m.Parse("notcassandra.cassandra23.invalid_logins.rate.ignored")
+			Convey("should parse without error", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("should not have fallen though so metric should be last two terms", func() {
+				So(metric, ShouldEqual, "invalid_logins.rate")
+			})
+			Convey("should be a gauge", func() {
+				So(metricType, ShouldEqual, datapoint.Gauge)
+			})
+			dims := map[string]string{"service": "notcassandra", "instance": "cassandra23"}
+			Convey("should parse dimensions correctly", func() {
+				So(dimensions, ShouldResemble, dims)
+			})
+		})
+		Convey("line with four terms", func() {
+			metric, metricType, dimensions, err := m.Parse("gmail.gmail23.invalid_logins.rate")
+			Convey("should parse without error", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("specified metric should be appended with last term", func() {
+				So(metric, ShouldEqual, "thinger.rate")
+			})
+			Convey("should be a gauge", func() {
+				So(metricType, ShouldEqual, datapoint.Gauge)
+			})
+			dims := map[string]string{"service": "gmail", "instance": "gmail23", "thang": "invalid_logins"}
+			Convey("pull the rest of the dimensions out", func() {
+				So(dimensions, ShouldResemble, dims)
+			})
+		})
+		Convey("line with four terms starting with counter", func() {
+			metric, metricType, dimensions, err := m.Parse("counter.gmail23.invalid_logins.rate")
+			Convey("should parse without error", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("specified metric should be appended with last term", func() {
+				So(metric, ShouldEqual, "thinger.rate")
+			})
+			Convey("should be a counter because of type rule starting with counter", func() {
+				So(metricType, ShouldEqual, datapoint.Count)
+			})
+			dims := map[string]string{"service": "counter", "instance": "gmail23", "thang": "invalid_logins"}
+			Convey("pull the rest of the dimensions out", func() {
+				So(dimensions, ShouldResemble, dims)
+			})
+		})
+		Convey("line with four terms ending with count", func() {
+			metric, metricType, dimensions, err := m.Parse("gmail.gmail23.invalid_logins.count")
+			Convey("should parse without error", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("specified metric should be appended with last term", func() {
+				So(metric, ShouldEqual, "thinger.count")
+			})
+			Convey("should be a counter because of type rule ending with count", func() {
+				So(metricType, ShouldEqual, datapoint.Count)
+			})
+			dims := map[string]string{"service": "gmail", "instance": "gmail23", "thang": "invalid_logins"}
+			Convey("pull the rest of the dimensions out", func() {
+				So(dimensions, ShouldResemble, dims)
+			})
+		})
+		Convey("line with eight terms", func() {
+			graphiteDim := "one.two.three.four.five.six.seven.eight"
+			metric, metricType, dimensions, err := m.Parse(graphiteDim)
+			Convey("should parse without error", func() {
+				So(err, ShouldBeNil)
+			})
+			Convey("metric should be the whole graphite metric due to no 8 term rule", func() {
+				So(metric, ShouldEqual, graphiteDim)
+			})
+			Convey("should be a gauge", func() {
+				So(metricType, ShouldEqual, datapoint.Gauge)
+			})
+			Convey("should have no dimensions", func() {
+				So(len(dimensions), ShouldEqual, 0)
+			})
+		})
+	})
+}
+
+func TestFallbackNil(t *testing.T) {
+	var fallback = `{
+  "FallbackDeconstructor":"nil",
+  "MetricRules": []
+}`
+	Convey("Given the config specifying the nil deconstructor", t, func() {
+		m, err := delimiterJSONLoader(getData(t, fallback))
+		Convey("should parse the config without error", func() {
+			So(err, ShouldBeNil)
+		})
+		Convey("line with seven terms", func() {
+			_, _, _, err = m.Parse("one.two.three.four.five.six.seven")
+			Convey("should parse giving an error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "nilDeconstructor always returns an error")
+			})
+		})
+	})
+}
+
+func TestBadConfigDifferentSizes(t *testing.T) {
+	var differentSizes = `{
+  "MetricRules": [
+	{
+	  "MetricPath": "*.*.*.*",
+	  "DimensionsMap": "service.instance.%"
+	}
+  ]
+}`
+	Convey("Given the bad config with metricpath having more terms than dimensionsmap", t, func() {
+		m, err := delimiterJSONLoader(getData(t, differentSizes))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "the MetricPath *.*.*.* has 4 terms but DimensionsMap service.instance.% has 3")
+		})
+	})
+}
+
+func TestBadConfigNoMetricName(t *testing.T) {
+	var noMetricName = `{
+  "MetricRules": [
+	{
+	  "MetricPath": "*.*.*",
+	  "DimensionsMap": "service.instance.-"
+	}
+  ]
+}`
+	Convey("Given the bad config with no metricName", t, func() {
+		m, err := delimiterJSONLoader(getData(t, noMetricName))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "the DimensionsMap does not have a metric specified; use % to specify the metric name override MetricName")
+		})
+	})
+}
+
+func TestBadConfigBadMetricType(t *testing.T) {
+	var badMetricType = `{
+  "MetricRules": [
+	{
+	  "MetricPath": "*.*.*",
+	  "DimensionsMap": "service.instance.%",
+	  "MetricType":"blarg"
+	}
+  ]
+}`
+	Convey("Given the bad config with bad metricType", t, func() {
+		m, err := delimiterJSONLoader(getData(t, badMetricType))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "cannot parse configured MetricType of blarg")
+		})
+	})
+}
+
+func TestBadFallbackDeconstructor(t *testing.T) {
+	var badFallback = `{
+  "FallbackDeconstructor": "blarg",
+  "MetricRules": [
+	{
+	  "MetricPath": "*.*.*",
+	  "DimensionsMap": "service.instance.%"
+	}
+  ]
+}`
+	Convey("Given the bad config with bad fallback", t, func() {
+		m, err := delimiterJSONLoader(getData(t, badFallback))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "unable to load metric deconstructor by the name of blarg")
+		})
+	})
+}
+
+func TestBadFallbackDeconstructorConfig(t *testing.T) {
+	var badFallback = `{
+  "FallbackDeconstructor": "commakeys",
+  "FallbackDeconstructorConfig": "blarg",
+  "MetricRules": [
+	{
+	  "MetricPath": "*.*.*",
+	  "DimensionsMap": "service.instance.%"
+	}
+  ]
+}`
+	Convey("Given the bad config with bad fallback config", t, func() {
+		m, err := delimiterJSONLoader(getData(t, badFallback))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "unknown commaKeysLoaderDeconstructor parameter blarg")
+		})
+	})
+}
+
+func TestInvalidMapToObject(t *testing.T) {
+	var invalidMapToObject = `{
+  "MetricRules": [
+	{
+	  "MetricPath": 4,
+	  "DimensionsMap": "service.instance.%"
+	}
+  ]
+}`
+	Convey("Given the bad config with bad json", t, func() {
+		m, err := delimiterJSONLoader(getData(t, invalidMapToObject))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "json: cannot unmarshal number into Go value of type string")
+		})
+	})
+}
+
+func TestNoType(t *testing.T) {
+	var noType = `{
+  "TypeRules": [
+    {
+      "StartsWith":"counter",
+      "EndsWith":"count"
+    }
+  ],
+  "MetricRules": []
+}`
+	Convey("Given the bad config with no type", t, func() {
+		m, err := delimiterJSONLoader(getData(t, noType))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err, ShouldEqual, errTypeRuleNotDefined)
+		})
+	})
+}
+
+func TestNoRules(t *testing.T) {
+	var noRules = `{
+  "TypeRules": [
+    {
+      "MetricType": "count"
+    }
+  ],
+  "MetricRules": []
+}`
+	Convey("Given the bad config with no type", t, func() {
+		m, err := delimiterJSONLoader(getData(t, noRules))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err, ShouldEqual, errTypeRuleIllDefined)
+		})
+	})
+}
+
+func TestInvalidType(t *testing.T) {
+	var invalidType = `{
+  "TypeRules": [
+    {
+      "MetricType": "blarg",
+      "StartsWith":"counter",
+      "EndsWith":"count"
+    }
+  ],
+  "MetricRules": []
+}`
+	Convey("Given the bad config with invalid type", t, func() {
+		m, err := delimiterJSONLoader(getData(t, invalidType))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "cannot parse configured MetricType of blarg")
+		})
+	})
+}
+
+func TestDuplicateDelimiter(t *testing.T) {
+	var duplicateDelimiter = `{
+  "OrDelimiter":".",
+  "MetricRules": []
+}`
+	Convey("Given the bad config with invalid type", t, func() {
+		m, err := delimiterJSONLoader(getData(t, duplicateDelimiter))
+		Convey("should parse the config and err", func() {
+			So(err, ShouldNotBeNil)
+			So(m, ShouldBeNil)
+			So(err.Error(), ShouldEqual, "overridden option cannot be the same as another: .")
+		})
+	})
+}
+
+func TestOverrideEverything(t *testing.T) {
+	var overrideEverything = `{
+  "OrDelimiter":"*",
+  "NotDelimiter":"-",
+  "Delimiter":"%",
+  "Globbing":"|",
+  "IgnoreDimension":"!",
+  "MetricIdentifier":".",
+  "Dimensions": { "key":"value"},
+  "MetricRules": [
+	{
+	  "DimensionsMap": "service%instance%."
+	}
+  ]
+}`
+	Convey("Given the config with everything overridden", t, func() {
+		m, err := delimiterJSONLoader(getData(t, overrideEverything))
+		Convey("should parse the config without errors", func() {
+			So(m, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+			Convey("a line with 3 terms and with % as a delimiter", func() {
+				metric, metricType, dimensions, err := m.Parse("cassandra%cassandra23%invalid_logins")
+				Convey("should parse without error", func() {
+					So(err, ShouldBeNil)
+				})
+				Convey("metric should last term", func() {
+					So(metric, ShouldEqual, "invalid_logins")
+				})
+				Convey("should be a gauge", func() {
+					So(metricType, ShouldEqual, datapoint.Gauge)
+				})
+				dims := map[string]string{"service": "cassandra", "instance": "cassandra23", "key": "value"}
+				Convey("should have no dimensions", func() {
+					So(dimensions, ShouldResemble, dims)
+				})
+			})
+		})
+	})
+}

--- a/protocol/carbon/metricdeconstructor/metricdeconstructor.go
+++ b/protocol/carbon/metricdeconstructor/metricdeconstructor.go
@@ -7,18 +7,20 @@ import (
 )
 
 // MetricDeconstructor is an object that can deconstruct a single metric name into what dimensions
-// it should represent.  Useful for compatability with non dimentioned stores, like graphite
+// it should represent.  Useful for compatibility with non dimensioned stores, like graphite
 type MetricDeconstructor interface {
 	Parse(originalMetric string) (newMetric string, mtype datapoint.MetricType, dimension map[string]string, err error)
 }
 
 type loader func(string) (MetricDeconstructor, error)
+type loadJSON func(map[string]interface{}) (MetricDeconstructor, error)
 
 var knownLoaders = map[string]loader{
 	"":          identityLoader,
 	"identity":  identityLoader,
 	"datadog":   commaKeysLoader,
 	"commakeys": commaKeysLoader,
+	"nil":       nilLoader,
 }
 
 // Load will load a MetricDeconstructor of the given name, with the given options
@@ -26,6 +28,19 @@ func Load(name string, options string) (MetricDeconstructor, error) {
 	loader, exists := knownLoaders[name]
 	if !exists {
 		return nil, fmt.Errorf("unable to load metric deconstructor by the name of %s", name)
+	}
+	return loader(options)
+}
+
+var knownJSONLoaders = map[string]loadJSON{
+	"delimiter": delimiterJSONLoader,
+}
+
+// LoadJSON will load a MetricDeconstructor of the given name, with the given JSON object
+func LoadJSON(name string, options map[string]interface{}) (MetricDeconstructor, error) {
+	loader, exists := knownJSONLoaders[name]
+	if !exists {
+		return nil, fmt.Errorf("unable to load from json metric deconstructor by the name of %s", name)
 	}
 	return loader(options)
 }

--- a/protocol/carbon/metricdeconstructor/metricdeconstructor_test.go
+++ b/protocol/carbon/metricdeconstructor/metricdeconstructor_test.go
@@ -23,3 +23,13 @@ func TestLoad(t *testing.T) {
 	assert.Nil(t, m)
 	assert.Error(t, err)
 }
+
+func TestLoadJSON(t *testing.T) {
+	m, err := LoadJSON("delimiter", make(map[string]interface{}))
+	assert.NotNil(t, m)
+	assert.NoError(t, err)
+
+	m, err = LoadJSON("NOTFOUND", make(map[string]interface{}))
+	assert.Nil(t, m)
+	assert.Error(t, err)
+}

--- a/protocol/carbon/metricdeconstructor/nildeconstructor.go
+++ b/protocol/carbon/metricdeconstructor/nildeconstructor.go
@@ -1,0 +1,18 @@
+package metricdeconstructor
+
+import (
+	"errors"
+
+	"github.com/signalfx/golib/datapoint"
+)
+
+type nilDeconstructor struct{}
+
+// Parse always returns an error
+func (m *nilDeconstructor) Parse(originalMetric string) (string, datapoint.MetricType, map[string]string, error) {
+	return "", datapoint.Gauge, nil, errors.New("nilDeconstructor always returns an error")
+}
+
+func nilLoader(options string) (MetricDeconstructor, error) {
+	return &nilDeconstructor{}, nil
+}


### PR DESCRIPTION
create configurable delimiter deconstructor
add a way to configure a deconstructor with json instead of just a string
added a nil deconstructor that only ever errors if they want to not send any metrics unless they bind