### PR TITLE
Added support in  the proxy for events as a top level both json and and protobuf, and the forwarding of events onto via protobuf to ingest. Also split the Sink Interface into DSink and ESink so the interfaces can be used individually.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,9 +1,6 @@
 {
 	"ImportPath": "github.com/signalfx/metricproxy",
 	"GoVersion": "go1.5.1",
-	"Packages": [
-		"./..."
-	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -39,10 +36,6 @@
 			"Rev": "47e8f450ef38c857cdd922ec08862ca9d65a1c6d"
 		},
 		{
-			"ImportPath": "github.com/jtolds/gls",
-			"Rev": "9a4a02dbe491bef4bab3c24fd9f3087d6c4c6690"
-		},
-		{
 			"ImportPath": "github.com/signalfx/com_signalfx_metrics_protobuf",
 			"Rev": "4ee27186f23ce032939bb7363a04c653c333139c"
 		},
@@ -55,26 +48,12 @@
 			"Rev": "9f10d93a91220d2a68751a64b4c0fe4d6b219839"
 		},
 		{
-			"ImportPath": "github.com/signalfx/golib/nettest",
-			"Rev": "9f10d93a91220d2a68751a64b4c0fe4d6b219839"
-		},
-		{
 			"ImportPath": "github.com/signalfx/golib/timekeeper",
 			"Rev": "9f10d93a91220d2a68751a64b4c0fe4d6b219839"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/web",
 			"Rev": "9f10d93a91220d2a68751a64b4c0fe4d6b219839"
-		},
-		{
-			"ImportPath": "github.com/smartystreets/assertions",
-			"Comment": "1.5.0-397-gac6b6f6",
-			"Rev": "ac6b6f68ca3d6ac00a360d0fad0c844859ad131b"
-		},
-		{
-			"ImportPath": "github.com/smartystreets/goconvey/convey",
-			"Comment": "1.5.0-432-g6a613df",
-			"Rev": "6a613dfb77d9fd2df760901a46339b33694d9bd1"
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",

--- a/dp/dpsink/sink.go
+++ b/dp/dpsink/sink.go
@@ -6,11 +6,23 @@ import (
 	"golang.org/x/net/context"
 )
 
+// A DSink is an object that can accept datapoints and do something with them, like forward them
+// to some endpoint
+type DSink interface {
+	AddDatapoints(ctx context.Context, points []*datapoint.Datapoint) error
+}
+
+// A ESink is an object that can accept events and do something with them, like forward them
+// to some endpoint
+type ESink interface {
+	AddEvents(ctx context.Context, events []*event.Event) error
+}
+
 // A Sink is an object that can accept datapoints or events and do something with them, like forward them
 // to some endpoint
 type Sink interface {
-	AddDatapoints(ctx context.Context, points []*datapoint.Datapoint) error
-	AddEvents(ctx context.Context, events []*event.Event) error
+	DSink
+	ESink
 }
 
 // NextSink is a special case of a sink that forwards to another sink

--- a/dp/dptest/generator.go
+++ b/dp/dptest/generator.go
@@ -30,7 +30,7 @@ func init() {
 	globalSource.TimeSource = time.Now
 	globalEventSource.EventType = "imanotify.notify_type"
 	globalEventSource.Dims = map[string]string{"host": "mwp-signalbox", "plugin": "my_plugin", "f": "x", "plugin_instance": "my_plugin_instance", "k": "v"}
-	globalEventSource.Meta = map[string]interface{}{"key": "value", "severity": "OKAY", "message": "my_message"}
+	globalEventSource.Meta = map[string]interface{}{"string": "value", "boolean": true, "int": int64(40), "double": 0.0, "": "nothing"}
 	globalEventSource.TimeSource = time.Now
 }
 

--- a/protocol/signalfx/signalfx.go
+++ b/protocol/signalfx/signalfx.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/signalfx/com_signalfx_metrics_protobuf"
 	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/event"
 )
 
 // JSONDatapointV1 is the JSON API format for /v1/datapoint
@@ -146,4 +147,44 @@ func NewProtobufDataPointWithType(dp *com_signalfx_metrics_protobuf.DataPoint, m
 	}
 
 	return datapoint.New(dp.GetMetric(), dims, NewDatumValue(dp.GetValue()), fromMT(mt), fromTs(dp.GetTimestamp())), nil
+}
+
+// NewProtobufEvent creates a new event from SignalFx's protobuf definition
+func NewProtobufEvent(e *com_signalfx_metrics_protobuf.Event) (*event.Event, error) {
+	dims := make(map[string]string, len(e.GetDimensions())+1)
+	edims := e.GetDimensions()
+	for _, dpdim := range edims {
+		dims[dpdim.GetKey()] = dpdim.GetValue()
+	}
+
+	// sure wish protobuf has something eqiv of interface{} instead of only union structs...
+	// <sigh>
+	props := make(map[string]interface{}, len(e.GetDimensions())+1)
+	for _, dpdim := range e.GetProperties() {
+		pval := dpdim.GetValue()
+		pkey := dpdim.GetKey()
+		if pval.StrValue != nil {
+			props[pkey] = pval.GetStrValue()
+		} else if pval.BoolValue != nil {
+			props[pkey] = pval.GetBoolValue()
+		} else if pval.DoubleValue != nil {
+			props[pkey] = pval.GetDoubleValue()
+		} else if pval.IntValue != nil {
+			props[pkey] = pval.GetIntValue()
+		}
+	}
+
+	return event.NewWithMeta(e.GetEventType(), e.GetCategory().String(), dims, props, fromTs(e.GetTimestamp())), nil
+}
+
+// JSONEventV2 is the V2 json event sending format
+type JSONEventV2 []*EventSendFormatV2
+
+// EventSendFormatV2 is the JSON format signalfx datapoints are expected to be in
+type EventSendFormatV2 struct {
+	EventType  string                 `json:"eventType"`
+	Category   *string                `json:"category"`
+	Dimensions map[string]string      `json:"dimensions"`
+	Properties map[string]interface{} `json:"properties"`
+	Timestamp  *int64                 `json:"timestamp"`
 }

--- a/protocol/signalfx/signalfx.go
+++ b/protocol/signalfx/signalfx.go
@@ -149,6 +149,8 @@ func NewProtobufDataPointWithType(dp *com_signalfx_metrics_protobuf.DataPoint, m
 	return datapoint.New(dp.GetMetric(), dims, NewDatumValue(dp.GetValue()), fromMT(mt), fromTs(dp.GetTimestamp())), nil
 }
 
+var errPropertyValueNotSet = errors.New("property value not set")
+
 // NewProtobufEvent creates a new event from SignalFx's protobuf definition
 func NewProtobufEvent(e *com_signalfx_metrics_protobuf.Event) (*event.Event, error) {
 	dims := make(map[string]string, len(e.GetDimensions())+1)
@@ -171,8 +173,9 @@ func NewProtobufEvent(e *com_signalfx_metrics_protobuf.Event) (*event.Event, err
 			props[pkey] = pval.GetDoubleValue()
 		} else if pval.IntValue != nil {
 			props[pkey] = pval.GetIntValue()
+		} else {
+			return nil, errPropertyValueNotSet
 		}
-		// protobuf format only has these 4 values so no else would be reachable
 	}
 
 	return event.NewWithMeta(e.GetEventType(), e.GetCategory().String(), dims, props, fromTs(e.GetTimestamp())), nil

--- a/protocol/signalfx/signalfx.go
+++ b/protocol/signalfx/signalfx.go
@@ -172,6 +172,7 @@ func NewProtobufEvent(e *com_signalfx_metrics_protobuf.Event) (*event.Event, err
 		} else if pval.IntValue != nil {
 			props[pkey] = pval.GetIntValue()
 		}
+		// protobuf format only has these 4 values so no else would be reachable
 	}
 
 	return event.NewWithMeta(e.GetEventType(), e.GetCategory().String(), dims, props, fromTs(e.GetTimestamp())), nil

--- a/protocol/signalfx/signalfx_test.go
+++ b/protocol/signalfx/signalfx_test.go
@@ -66,6 +66,26 @@ func TestNewProtobufDataPointWithType(t *testing.T) {
 	})
 }
 
+func TestNewProtobufEvent(t *testing.T) {
+	Convey("given a protobuf event with a nil property value", t, func() {
+		protoEvent := &com_signalfx_metrics_protobuf.Event{
+			EventType:  workarounds.GolangDoesnotAllowPointerToStringLiteral("mwp.test2"),
+			Dimensions: []*com_signalfx_metrics_protobuf.Dimension{},
+			Properties: []*com_signalfx_metrics_protobuf.Property{
+				{
+					Key:   workarounds.GolangDoesnotAllowPointerToStringLiteral("version"),
+					Value: &com_signalfx_metrics_protobuf.PropertyValue{},
+				},
+			},
+		}
+		Convey("should error when converted", func() {
+			_, err := NewProtobufEvent(protoEvent)
+			So(err, ShouldEqual, errPropertyValueNotSet)
+		})
+
+	})
+}
+
 func TestConver(t *testing.T) {
 	assert.Panics(t, func() {
 		toMT(datapoint.MetricType(1001))

--- a/protocol/signalfx/signalfxforwarder.go
+++ b/protocol/signalfx/signalfxforwarder.go
@@ -152,7 +152,7 @@ func (connector *Forwarder) encodeEventPostBodyProtobufV2(events []*event.Event)
 	}
 	protobytes, err := connector.protoMarshal(msg)
 
-	// Now we can send datapoints
+	// Now we can send events
 	return protobytes, "application/x-protobuf", err
 }
 
@@ -233,9 +233,10 @@ func mapToProperties(properties map[string]interface{}) []*com_signalfx_metrics_
 			pv.DoubleValue = &dval
 		} else if sval, ok := v.(string); ok {
 			pv.StrValue = &sval
+		} else {
+			// ignore, shouldn't be possible to get here from external source
+			continue
 		}
-		// else ignore, i was unable to come up with a way to send in something
-		// that wasn't one of these from an external source
 
 		ret = append(ret, (&com_signalfx_metrics_protobuf.Property{
 			Key:   &copyOfK,

--- a/protocol/signalfx/signalfxforwarder.go
+++ b/protocol/signalfx/signalfxforwarder.go
@@ -222,7 +222,7 @@ func mapToProperties(properties map[string]interface{}) []*com_signalfx_metrics_
 		if k == "" || v == nil {
 			continue
 		}
-		copyOfK := filterSignalfxKey(string([]byte(k)))
+		copyOfK := filterSignalfxKey(k)
 
 		pv := com_signalfx_metrics_protobuf.PropertyValue{}
 		if ival, ok := v.(int64); ok {
@@ -234,6 +234,8 @@ func mapToProperties(properties map[string]interface{}) []*com_signalfx_metrics_
 		} else if sval, ok := v.(string); ok {
 			pv.StrValue = &sval
 		}
+		// else ignore, i was unable to come up with a way to send in something
+		// that wasn't one of these from an external source
 
 		ret = append(ret, (&com_signalfx_metrics_protobuf.Property{
 			Key:   &copyOfK,
@@ -248,10 +250,9 @@ func mapToDimensions(dimensions map[string]string) []*com_signalfx_metrics_proto
 		if k == "" || v == "" {
 			continue
 		}
-		// If someone knows a better way to do this, let me know.  I can't just take the &
-		// of k and v because their content changes as the range iterates
-		copyOfK := filterSignalfxKey(string([]byte(k)))
-		copyOfV := (string([]byte(v)))
+		copyOfK := filterSignalfxKey(k)
+		copyOfV := v
+
 		ret = append(ret, (&com_signalfx_metrics_protobuf.Dimension{
 			Key:   &copyOfK,
 			Value: &copyOfV,

--- a/protocol/signalfx/signalfxforwarder.go
+++ b/protocol/signalfx/signalfxforwarder.go
@@ -52,7 +52,7 @@ type Forwarder struct {
 
 var defaultConfigV2 = &config.ForwardTo{
 	URL:               workarounds.GolangDoesnotAllowPointerToStringLiteral("https://ingest.signalfx.com/v2/datapoint"),
-	EventURL:          workarounds.GolangDoesnotAllowPointerToStringLiteral("https://api.signalfx.com/v1/event"),
+	EventURL:          workarounds.GolangDoesnotAllowPointerToStringLiteral("https://ingest.signalfx.com/v2/event"),
 	DefaultSource:     workarounds.GolangDoesnotAllowPointerToStringLiteral(""),
 	MetricCreationURL: workarounds.GolangDoesnotAllowPointerToStringLiteral(""), // Not used
 	TimeoutDuration:   workarounds.GolangDoesnotAllowPointerToTimeLiteral(time.Second * 60),
@@ -142,33 +142,18 @@ func (connector *Forwarder) encodePostBodyProtobufV2(datapoints []*datapoint.Dat
 	return protobytes, "application/x-protobuf", err
 }
 
-// JSONEvent is used to wrap event object so we can format it as expected
-type JSONEvent struct {
-	EventType  string                 `json:"eventType"`
-	Category   string                 `json:"category"`
-	Dimensions map[string]string      `json:"dimensions"`
-	Meta       map[string]interface{} `json:"properties"`
-	Timestamp  int64                  `json:"timestamp"`
-}
-
-func newJSONEvent(event *event.Event) *JSONEvent {
-	return &JSONEvent{EventType: event.EventType,
-		Category:   event.Category,
-		Dimensions: event.Dimensions,
-		Meta:       event.Meta,
-		Timestamp:  event.Timestamp.UnixNano() / time.Millisecond.Nanoseconds()}
-}
-
-func (connector *Forwarder) encodeEventPostBodyJSON(events []*event.Event) ([]byte, error) {
-	var buffer []byte
-	for i := range events {
-		protobytes, err := connector.jsonMarshal(newJSONEvent(events[i]))
-		if err != nil {
-			return buffer, err
-		}
-		buffer = append(buffer, protobytes...)
+func (connector *Forwarder) encodeEventPostBodyProtobufV2(events []*event.Event) ([]byte, string, error) {
+	evts := make([]*com_signalfx_metrics_protobuf.Event, 0, len(events))
+	for _, evt := range events {
+		evts = append(evts, connector.coreEventToProtobuf(evt))
 	}
-	return buffer, nil
+	msg := &com_signalfx_metrics_protobuf.EventUploadMessage{
+		Events: evts,
+	}
+	protobytes, err := connector.protoMarshal(msg)
+
+	// Now we can send datapoints
+	return protobytes, "application/x-protobuf", err
 }
 
 func datumForPoint(pv datapoint.Value) *com_signalfx_metrics_protobuf.Datum {
@@ -213,6 +198,50 @@ func (connector *Forwarder) coreDatapointToProtobuf(point *datapoint.Datapoint) 
 	return v
 }
 
+func (connector *Forwarder) coreEventToProtobuf(e *event.Event) *com_signalfx_metrics_protobuf.Event {
+	ts := e.Timestamp.UnixNano() / time.Millisecond.Nanoseconds()
+	et := e.EventType
+	cat := com_signalfx_metrics_protobuf.EventCategory_USER_DEFINED
+	if catIndex, ok := com_signalfx_metrics_protobuf.EventCategory_value[e.Category]; ok {
+		cat = com_signalfx_metrics_protobuf.EventCategory(catIndex)
+	}
+
+	v := &com_signalfx_metrics_protobuf.Event{
+		EventType:  &et,
+		Timestamp:  &ts,
+		Properties: mapToProperties(e.Meta),
+		Dimensions: mapToDimensions(e.Dimensions),
+		Category:   &cat,
+	}
+	return v
+}
+
+func mapToProperties(properties map[string]interface{}) []*com_signalfx_metrics_protobuf.Property {
+	ret := make([]*com_signalfx_metrics_protobuf.Property, 0, len(properties))
+	for k, v := range properties {
+		if k == "" || v == nil {
+			continue
+		}
+		copyOfK := filterSignalfxKey(string([]byte(k)))
+
+		pv := com_signalfx_metrics_protobuf.PropertyValue{}
+		if ival, ok := v.(int64); ok {
+			pv.IntValue = &ival
+		} else if bval, ok := v.(bool); ok {
+			pv.BoolValue = &bval
+		} else if dval, ok := v.(float64); ok {
+			pv.DoubleValue = &dval
+		} else if sval, ok := v.(string); ok {
+			pv.StrValue = &sval
+		}
+
+		ret = append(ret, (&com_signalfx_metrics_protobuf.Property{
+			Key:   &copyOfK,
+			Value: &pv,
+		}))
+	}
+	return ret
+}
 func mapToDimensions(dimensions map[string]string) []*com_signalfx_metrics_protobuf.Dimension {
 	ret := make([]*com_signalfx_metrics_protobuf.Dimension, 0, len(dimensions))
 	for k, v := range dimensions {
@@ -320,15 +349,14 @@ func (connector *Forwarder) AddEvents(ctx context.Context, events []*event.Event
 	if len(events) == 0 {
 		return nil
 	}
-	jsonBytes, err := connector.encodeEventPostBodyJSON(events)
-
+	protoBytes, bodyType, err := connector.encodeEventPostBodyProtobufV2(events)
 	if err != nil {
 		return &forwardError{
 			originalError: err,
 			message:       "Unable to marshal object",
 		}
 	}
-	return connector.sendBytes(endpoint, "application/json", defaultAuthToken, userAgent, jsonBytes)
+	return connector.sendBytes(endpoint, bodyType, defaultAuthToken, userAgent, protoBytes)
 }
 
 var atomicRequestNumber = int64(0)

--- a/protocol/signalfx/signalfxlistener.go
+++ b/protocol/signalfx/signalfxlistener.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/signalfx/com_signalfx_metrics_protobuf"
 	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/event"
 	"github.com/signalfx/golib/web"
 	"github.com/signalfx/metricproxy/config"
 	"github.com/signalfx/metricproxy/dp/dplocal"
@@ -221,6 +222,38 @@ func (decoder *ProtobufDecoderV2) Read(ctx context.Context, req *http.Request) e
 	return decoder.Sink.AddDatapoints(ctx, dps)
 }
 
+// ProtobufEventDecoderV2 decodes protocol buffers in signalfx's v2 format and sends them to Sink
+type ProtobufEventDecoderV2 struct {
+	Sink dpsink.Sink
+}
+
+func (decoder *ProtobufEventDecoderV2) Read(ctx context.Context, req *http.Request) error {
+	if req.ContentLength == -1 {
+		return errInvalidContentLength
+	}
+
+	// TODO: Source of memory creation.  Maybe pass buf in?
+	buf := make([]byte, req.ContentLength)
+	readLen, err := io.ReadFull(req.Body, buf)
+	if err != nil {
+		log.WithField("err", err).WithField("len", readLen).WithField("content-len", req.ContentLength).Warn("Unable to fully read from buffer")
+		return err
+	}
+	var msg com_signalfx_metrics_protobuf.EventUploadMessage
+	err = proto.Unmarshal(buf, &msg)
+	if err != nil {
+		log.Debug("Unable to unmarshal")
+		return err
+	}
+	evts := make([]*event.Event, 0, len(msg.GetEvents()))
+	for _, protoDb := range msg.GetEvents() {
+		if e, err := NewProtobufEvent(protoDb); err == nil {
+			evts = append(evts, e)
+		}
+	}
+	return decoder.Sink.AddEvents(ctx, evts)
+}
+
 // JSONDecoderV2 decodes v2 json data for signalfx and sends it to Sink
 type JSONDecoderV2 struct {
 	Sink dpsink.Sink
@@ -250,6 +283,31 @@ func (decoder *JSONDecoderV2) Read(ctx context.Context, req *http.Request) error
 		}
 	}
 	return decoder.Sink.AddDatapoints(ctx, dps)
+}
+
+// JSONEventDecoderV2 decodes v2 json data for signalfx events and sends it to Sink
+type JSONEventDecoderV2 struct {
+	Sink dpsink.Sink
+}
+
+func (decoder *JSONEventDecoderV2) Read(ctx context.Context, req *http.Request) error {
+	dec := json.NewDecoder(req.Body)
+	var e JSONEventV2
+	if err := dec.Decode(&e); err != nil {
+		return err
+	}
+	evts := make([]*event.Event, 0, len(e))
+	for _, jsonEvent := range e {
+		if jsonEvent.Category == nil {
+			jsonEvent.Category = workarounds.GolangDoesnotAllowPointerToStringLiteral("USER_DEFINED")
+		}
+		if jsonEvent.Timestamp == nil {
+			jsonEvent.Timestamp = workarounds.GolangDoesnotAllowPointerToIntLiteral(0)
+		}
+		evt := event.NewWithMeta(jsonEvent.EventType, *jsonEvent.Category, jsonEvent.Dimensions, jsonEvent.Properties, fromTs(*jsonEvent.Timestamp))
+		evts = append(evts, evt)
+	}
+	return decoder.Sink.AddEvents(ctx, evts)
 }
 
 var defaultConfig = &config.ListenFrom{
@@ -355,7 +413,9 @@ func StartServingHTTPOnPort(ctx context.Context, sink dpsink.Sink, listenAddr st
 		setupProtobufV1(r, ctx, name, sink, &metricHandler),
 		setupJSONV1(r, ctx, name, sink, &metricHandler),
 		setupProtobufV2(r, ctx, name, sink),
+		setupProtobufEventV2(r, ctx, name, sink),
 		setupJSONV2(r, ctx, name, sink),
+		setupJSONEventV2(r, ctx, name, sink),
 		setupCollectd(r, ctx, name, sink))
 
 	go server.Serve(listener)
@@ -404,50 +464,82 @@ func setupJSONV1(r *mux.Router, ctx context.Context, name string, sink dpsink.Si
 	handler, st := setupChain(ctx, sink, name, "json_v1", func(s dpsink.Sink) ErrorReader {
 		return &JSONDecoderV1{Sink: s, TypeGetter: typeGetter}
 	})
-
 	SetupJSONV1Paths(r, handler)
+
 	return st
 }
 
 // SetupJSONV1Paths routes to R paths that should handle V1 JSON datapoints
 func SetupJSONV1Paths(r *mux.Router, handler http.Handler) {
-	r.Path("/datapoint").Methods("POST").Headers("Content-Type", "application/json").Handler(handler)
-	r.Path("/v1/datapoint").Methods("POST").Headers("Content-Type", "application/json").Handler(handler)
-	r.Path("/datapoint").Methods("POST").Headers("Content-Type", "").HandlerFunc(invalidContentType)
-	r.Path("/v1/datapoint").Methods("POST").Headers("Content-Type", "").HandlerFunc(invalidContentType)
-	r.Path("/datapoint").Methods("POST").Handler(handler)
-	r.Path("/v1/datapoint").Methods("POST").Handler(handler)
+	SetupJSONByPaths(r, handler, "/datapoint")
+	SetupJSONByPaths(r, handler, "/v1/datapoint")
 }
 
 func setupProtobufV2(r *mux.Router, ctx context.Context, name string, sink dpsink.Sink) stats.Keeper {
 	handler, st := setupChain(ctx, sink, name, "protobuf_v2", func(s dpsink.Sink) ErrorReader {
 		return &ProtobufDecoderV2{Sink: s}
 	})
-	SetupProtobufV2Paths(r, handler)
+	SetupProtobufV2DatapointPaths(r, handler)
 
 	return st
 }
 
-// SetupProtobufV2Paths tells the router which paths the given handler (which should handle v2 protobufs)
-// should see
-func SetupProtobufV2Paths(r *mux.Router, handler http.Handler) {
-	r.Path("/v2/datapoint").Methods("POST").Headers("Content-Type", "application/x-protobuf").Handler(handler)
+func setupProtobufEventV2(r *mux.Router, ctx context.Context, name string, sink dpsink.Sink) stats.Keeper {
+	handler, st := setupChain(ctx, sink, name, "protobuf_v2", func(s dpsink.Sink) ErrorReader {
+		return &ProtobufEventDecoderV2{Sink: s}
+	})
+	SetupProtobufV2EventPaths(r, handler)
+
+	return st
+}
+
+// SetupProtobufV2DatapointPaths tells the router which paths the given handler (which should handle v2 protobufs)
+func SetupProtobufV2DatapointPaths(r *mux.Router, handler http.Handler) {
+	SetupProtobufV2ByPaths(r, handler, "/v2/datapoint")
+}
+
+// SetupProtobufV2EventPaths tells the router which paths the given handler (which should handle v2 protobufs)
+func SetupProtobufV2EventPaths(r *mux.Router, handler http.Handler) {
+	SetupProtobufV2ByPaths(r, handler, "/v2/event")
+}
+
+// SetupProtobufV2ByPaths tells the router which paths the given handler (which should handle v2 protobufs)
+func SetupProtobufV2ByPaths(r *mux.Router, handler http.Handler, path string) {
+	r.Path(path).Methods("POST").Headers("Content-Type", "application/x-protobuf").Handler(handler)
 }
 
 func setupJSONV2(r *mux.Router, ctx context.Context, name string, sink dpsink.Sink) stats.Keeper {
 	handler, st := setupChain(ctx, sink, name, "json_v2", func(s dpsink.Sink) ErrorReader {
 		return &JSONDecoderV2{Sink: s}
 	})
-	SetupJSONV2Paths(r, handler)
+	SetupJSONV2DatapointPaths(r, handler)
 	return st
 }
 
-// SetupJSONV2Paths tells the router which paths the given handler (which should handle v2 JSON)
-// should see
-func SetupJSONV2Paths(r *mux.Router, handler http.Handler) {
-	r.Path("/v2/datapoint").Methods("POST").Headers("Content-Type", "application/json").Handler(handler)
-	r.Path("/v2/datapoint").Methods("POST").Headers("Content-Type", "").HandlerFunc(invalidContentType)
-	r.Path("/v2/datapoint").Methods("POST").Handler(handler)
+func setupJSONEventV2(r *mux.Router, ctx context.Context, name string, sink dpsink.Sink) stats.Keeper {
+	handler, st := setupChain(ctx, sink, name, "json_event_v2", func(s dpsink.Sink) ErrorReader {
+		return &JSONEventDecoderV2{Sink: s}
+	})
+	SetupJSONV2EventPaths(r, handler)
+	return st
+}
+
+// SetupJSONV2DatapointPaths tells the router which paths the given handler (which should handle v2 protobufs)
+func SetupJSONV2DatapointPaths(r *mux.Router, handler http.Handler) {
+	SetupJSONByPaths(r, handler, "/v2/datapoint")
+}
+
+// SetupJSONV2EventPaths tells the router which paths the given handler (which should handle v2 protobufs)
+func SetupJSONV2EventPaths(r *mux.Router, handler http.Handler) {
+	SetupJSONByPaths(r, handler, "/v2/event")
+}
+
+// SetupJSONByPaths tells the router which paths the given handler (which should handle the given
+// endpoint) should see
+func SetupJSONByPaths(r *mux.Router, handler http.Handler, endpoint string) {
+	r.Path(endpoint).Methods("POST").Headers("Content-Type", "application/json").Handler(handler)
+	r.Path(endpoint).Methods("POST").Headers("Content-Type", "").HandlerFunc(invalidContentType)
+	r.Path(endpoint).Methods("POST").Handler(handler)
 }
 
 func setupCollectd(r *mux.Router, ctx context.Context, name string, sink dpsink.Sink) stats.Keeper {

--- a/protocol/signalfx/signalfxlistener.go
+++ b/protocol/signalfx/signalfxlistener.go
@@ -98,7 +98,7 @@ func (e *ErrorTrackerHandler) ServeHTTPC(ctx context.Context, rw http.ResponseWr
 
 // ProtobufDecoderV1 creates datapoints out of the V1 protobuf definition
 type ProtobufDecoderV1 struct {
-	Sink       dpsink.Sink
+	Sink       dpsink.DSink
 	TypeGetter MericTypeGetter
 }
 
@@ -163,7 +163,7 @@ func datapointProtobufIsInvalidForV1(msg *com_signalfx_metrics_protobuf.DataPoin
 // JSONDecoderV1 creates datapoints out of the v1 JSON definition
 type JSONDecoderV1 struct {
 	TypeGetter MericTypeGetter
-	Sink       dpsink.Sink
+	Sink       dpsink.DSink
 }
 
 func (decoder *JSONDecoderV1) Read(ctx context.Context, req *http.Request) error {
@@ -224,7 +224,7 @@ func (decoder *ProtobufDecoderV2) Read(ctx context.Context, req *http.Request) e
 
 // ProtobufEventDecoderV2 decodes protocol buffers in signalfx's v2 format and sends them to Sink
 type ProtobufEventDecoderV2 struct {
-	Sink dpsink.Sink
+	Sink dpsink.ESink
 }
 
 func (decoder *ProtobufEventDecoderV2) Read(ctx context.Context, req *http.Request) error {
@@ -287,7 +287,7 @@ func (decoder *JSONDecoderV2) Read(ctx context.Context, req *http.Request) error
 
 // JSONEventDecoderV2 decodes v2 json data for signalfx events and sends it to Sink
 type JSONEventDecoderV2 struct {
-	Sink dpsink.Sink
+	Sink dpsink.ESink
 }
 
 func (decoder *JSONEventDecoderV2) Read(ctx context.Context, req *http.Request) error {


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/signalfx/metricproxy/30)
<!-- Reviewable:end -->
