### PR TITLE
Context headers

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -51,67 +51,67 @@
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/datapoint",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/datapoint/dpsink",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/datapoint/dptest",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/errors",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/event",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/eventcounter",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/explorable",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/expvar2",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/httpdebug",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/log",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/logkey",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/nettest",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/pointer",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/sfxclient",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/timekeeper",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/signalfx/golib/web",
-			"Rev": "9f30497f6dbda13e66535434f8e676d82502426d"
+			"Rev": "0ec7586c6b34167e1f569f57af62cf513c1bfe96"
 		},
 		{
 			"ImportPath": "github.com/smartystreets/assertions",

--- a/Godeps/_workspace/src/github.com/signalfx/golib/log/ctxdims.go
+++ b/Godeps/_workspace/src/github.com/signalfx/golib/log/ctxdims.go
@@ -1,0 +1,36 @@
+package log
+
+import "golang.org/x/net/context"
+
+// CtxDimensions can propagate log dimensions inside a context object
+type CtxDimensions struct {
+}
+
+// From returns the dimensions currently set inside a context object
+func (c *CtxDimensions) From(ctx context.Context) []interface{} {
+	existing := ctx.Value(c)
+	if existing == nil {
+		return []interface{}{}
+	}
+	return existing.([]interface{})
+}
+
+// Append returns a new context that appends vals as dimensions for logging
+func (c *CtxDimensions) Append(ctx context.Context, vals ...interface{}) context.Context {
+	if len(vals) == 0 {
+		return ctx
+	}
+	if len(vals)%2 != 0 {
+		panic("Expected even number of values")
+	}
+	existing := c.From(ctx)
+	newArr := make([]interface{}, 0, len(existing)+len(vals))
+	newArr = append(newArr, existing...)
+	newArr = append(newArr, vals...)
+	return context.WithValue(ctx, c, newArr)
+}
+
+// With returns a new Context object that appends the dimensions inside ctx with the context logCtx
+func (c *CtxDimensions) With(ctx context.Context, log Logger) *Context {
+	return NewContext(log).With(c.From(ctx)...)
+}

--- a/Godeps/_workspace/src/github.com/signalfx/golib/log/ctxdims_test.go
+++ b/Godeps/_workspace/src/github.com/signalfx/golib/log/ctxdims_test.go
@@ -1,0 +1,37 @@
+package log
+
+import (
+	"bytes"
+	. "github.com/smartystreets/goconvey/convey"
+	"golang.org/x/net/context"
+	"testing"
+)
+
+func TestCtxDims(t *testing.T) {
+	Convey("default ctx dims", t, func() {
+		cd := &CtxDimensions{}
+		ctx := context.Background()
+		Convey("default get should be empty list", func() {
+			So(len(cd.From(ctx)), ShouldEqual, 0)
+		})
+		Convey("Odd append should panic", func() {
+			So(func() {
+				cd.Append(ctx, "ood_num")
+			}, ShouldPanic)
+		})
+		Convey("empty append should do nothing", func() {
+			So(cd.Append(ctx), ShouldEqual, ctx)
+		})
+		Convey("And a default append", func() {
+			ctx2 := cd.Append(ctx, "name", "john")
+			So(len(cd.From(ctx2)), ShouldEqual, 2)
+			So(len(cd.From(ctx)), ShouldEqual, 0)
+			Convey("With should append dims", func() {
+				buf := &bytes.Buffer{}
+				l := NewLogfmtLogger(buf, Panic)
+				cd.With(ctx2, l).Log()
+				So(buf.String(), ShouldContainSubstring, "john")
+			})
+		})
+	})
+}

--- a/Godeps/_workspace/src/github.com/signalfx/golib/sfxclient/httpsink.go
+++ b/Godeps/_workspace/src/github.com/signalfx/golib/sfxclient/httpsink.go
@@ -57,8 +57,7 @@ func NewHTTPDatapointSink() *HTTPDatapointSink {
 		UserAgent: DefaultUserAgent,
 		Endpoint:  IngestEndpointV2,
 		Client: http.Client{
-			Timeout:   DefaultTimeout,
-			Transport: http.DefaultTransport,
+			Timeout: DefaultTimeout,
 		},
 		protoMarshaler: proto.Marshal,
 	}

--- a/Godeps/_workspace/src/github.com/signalfx/golib/sfxclient/httpsink_test.go
+++ b/Godeps/_workspace/src/github.com/signalfx/golib/sfxclient/httpsink_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"golang.org/x/net/context"
 	"net"
+	"strings"
 )
 
 type errReader struct {
@@ -165,7 +166,10 @@ func TestHTTPDatapointSink(t *testing.T) {
 			Convey("context cancel should work", func() {
 				blockResponse = make(chan struct{})
 				ctx, cancelCallback = context.WithCancel(ctx)
-				So(errors.Details(s.AddDatapoints(ctx, dps)), ShouldContainSubstring, "canceled")
+				s := errors.Details(s.AddDatapoints(ctx, dps))
+				if !strings.Contains(s, "canceled") && !strings.Contains(s, "closed") {
+					t.Errorf("Bad error string %s", s)
+				}
 			})
 			Convey("timeouts should work", func() {
 				blockResponse = make(chan struct{})

--- a/Godeps/_workspace/src/github.com/signalfx/golib/sfxclient/sfxclient_test.go
+++ b/Godeps/_workspace/src/github.com/signalfx/golib/sfxclient/sfxclient_test.go
@@ -155,7 +155,6 @@ func TestNewScheduler(t *testing.T) {
 					}
 					firstPoints := <-sink.lastDatapoints
 					So(len(firstPoints), ShouldEqual, 1)
-					So(len(sink.lastDatapoints), ShouldEqual, 0)
 					Convey("and should skip an interval if we sleep too long", func() {
 						// Should eventually end
 						for atomic.LoadInt64(&s.stats.resetIntervalCounts) == 0 {

--- a/Godeps/_workspace/src/github.com/signalfx/golib/web/tester.go
+++ b/Godeps/_workspace/src/github.com/signalfx/golib/web/tester.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"golang.org/x/net/context"
+	"net/http"
+)
+
+// Request is a request put on the TestHandler queue that records eacn request sent through
+type Request struct {
+	Ctx context.Context
+	Rw  http.ResponseWriter
+	Req *http.Request
+}
+
+// Recorder stores into Queue each request that comes across the recorder
+type Recorder struct {
+	Queue chan Request
+}
+
+// ServeHTTPC stores the req into Queue and calls next
+func (t *Recorder) ServeHTTPC(ctx context.Context, rw http.ResponseWriter, r *http.Request, next ContextHandler) {
+	t.Queue <- Request{
+		Ctx: ctx,
+		Rw:  rw,
+		Req: r,
+	}
+	if next != nil {
+		next.ServeHTTPC(ctx, rw, r)
+	}
+}
+
+// AsHandler returns a Recoder that can be a destination handler
+func (t *Recorder) AsHandler() ContextHandler {
+	return HandlerFunc(func(ctx context.Context, rw http.ResponseWriter, r *http.Request) {
+		t.ServeHTTPC(ctx, rw, r, nil)
+	})
+}
+
+// ServeHTTP stores the request into the Queue
+func (t *Recorder) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	t.Queue <- Request{
+		Rw:  rw,
+		Req: r,
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,7 @@ type ProxyConfig struct {
 	LogFormat          *string        `json:",omitempty"`
 	PprofAddr          *string        `json:",omitempty"`
 	DebugFlag          *string        `json:",omitempty"`
+	ServerName         *string        `json:",omitempty"`
 }
 
 // DefaultProxyConfig is default values for the proxy config
@@ -86,6 +87,15 @@ var DefaultProxyConfig = &ProxyConfig{
 	LogMaxSize:    pointer.Int(100),
 	LogMaxBackups: pointer.Int(10),
 	LogFormat:     pointer.String(""),
+	ServerName:    pointer.String(getDefaultName(os.Hostname)),
+}
+
+func getDefaultName(osHostname func() (string, error)) string {
+	hostname, err := osHostname()
+	if err == nil {
+		return hostname
+	}
+	return "unknown"
 }
 
 func decodeConfig(configBytes []byte) (*ProxyConfig, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,6 +31,14 @@ func TestBadDecode(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGetDefaultName(t *testing.T) {
+	u := getDefaultName(func() (string, error) {
+		return "", errors.New("")
+	})
+	assert.Equal(t, u, "unknown")
+
+}
+
 func TestParseStatsDelay(t *testing.T) {
 	config, _ := decodeConfig([]byte(`{"StatsDelay":"3s"}`))
 	assert.Equal(t, *config.StatsDelayDuration, time.Second*3)

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -26,7 +26,7 @@ func TestConfigLoader(t *testing.T) {
 		debugContext := web.HeaderCtxFlag{}
 		itemFlagger := dpsink.ItemFlagger{}
 
-		l := NewLoader(ctx, logger, version, &debugContext, &itemFlagger)
+		l := NewLoader(ctx, logger, version, &debugContext, &itemFlagger, nil, nil)
 		Convey("should fail empty forwarders", func() {
 			_, err := l.Forwarder(&ForwardTo{})
 			So(err, ShouldNotBeNil)

--- a/dp/dpbuffered/bufferedforwarder_test.go
+++ b/dp/dpbuffered/bufferedforwarder_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"fmt"
-
 	"bytes"
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/datapoint/dpsink"
@@ -13,6 +11,8 @@ import (
 	"github.com/signalfx/golib/event"
 	"github.com/signalfx/golib/log"
 	"github.com/signalfx/golib/pointer"
+	"github.com/signalfx/golib/web"
+	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"io"
@@ -40,94 +40,109 @@ func (t *threadSafeWriter) Write(p []byte) (n int, err error) {
 
 // TODO figure out why this test is flaky, should be > 2, but change to >= 2 so it passes
 func TestBufferedForwarderBasic(t *testing.T) {
-	ctx := context.Background()
-	flagCheck := boolChecker(false)
-	checker := &dpsink.ItemFlagger{
-		CtxFlagCheck:        &flagCheck,
-		EventMetaName:       "meta_event",
-		MetricDimensionName: "sf_metric",
-	}
-	config := &Config{
-		BufferSize:         pointer.Int64(210),
-		MaxTotalDatapoints: pointer.Int64(1000),
-		MaxTotalEvents:     pointer.Int64(1000),
-		NumDrainingThreads: pointer.Int64(1),
-		MaxDrainSize:       pointer.Int64(1000),
-		Checker:            checker,
-	}
-	sendTo := dptest.NewBasicSink()
-	buf := &bytes.Buffer{}
-	threadWriter := &threadSafeWriter{Writer: buf}
-	l := log.NewLogfmtLogger(threadWriter, log.Panic)
-	bf := NewBufferedForwarder(ctx, config, sendTo, l)
-	defer bf.Close()
-	assert.NoError(t, bf.AddDatapoints(ctx, []*datapoint.Datapoint{}))
-	time.Sleep(time.Millisecond * 10)
-	datas := []*datapoint.Datapoint{
-		dptest.DP(),
-		dptest.DP(),
-	}
-	checker.SetDatapointFlag(datas[0])
-	for i := 0; i < 100; i++ {
-		assert.NoError(t, bf.AddDatapoints(ctx, datas))
-		if i == 0 {
+	Convey("Basic forwarder setup", t, func() {
+		ctx := context.Background()
+		flagCheck := boolChecker(false)
+		checker := &dpsink.ItemFlagger{
+			CtxFlagCheck:        &flagCheck,
+			EventMetaName:       "meta_event",
+			MetricDimensionName: "sf_metric",
+		}
+		config := &Config{
+			BufferSize:         pointer.Int64(210),
+			MaxTotalDatapoints: pointer.Int64(1000),
+			MaxTotalEvents:     pointer.Int64(1000),
+			NumDrainingThreads: pointer.Int64(1),
+			MaxDrainSize:       pointer.Int64(1000),
+			Checker:            checker,
+		}
+		sendTo := dptest.NewBasicSink()
+		buf := &bytes.Buffer{}
+		threadWriter := &threadSafeWriter{Writer: buf}
+		l := log.NewLogfmtLogger(threadWriter, log.Panic)
+		bf := NewBufferedForwarder(ctx, config, sendTo, l)
+		datas := []*datapoint.Datapoint{
+			dptest.DP(),
+			dptest.DP(),
+		}
+		events := []*event.Event{
+			dptest.E(),
+			dptest.E(),
+		}
+		Reset(func() {
+			So(bf.Close(), ShouldBeNil)
+		})
+		Convey("Should be able to send an event", func() {
+			assert.NoError(t, bf.AddEvents(ctx, []*event.Event{}))
+		})
+		Convey("Should be able to send a datapoint", func() {
+			assert.NoError(t, bf.AddDatapoints(ctx, []*datapoint.Datapoint{}))
+		})
+		Convey("Should export stats", func() {
+			So(len(bf.Datapoints()), ShouldEqual, numStats)
+		})
+		Convey("Should buffer points", func() {
+			time.Sleep(time.Millisecond * 10)
+			for i := 0; i < 100; i++ {
+				So(bf.AddDatapoints(ctx, datas), ShouldBeNil)
+				if i == 0 {
+					seen := <-sendTo.PointsChan
+					So(len(seen), ShouldEqual, 2)
+				}
+			}
+			So(bf.AddDatapoints(ctx, datas), ShouldBeNil)
+		})
+		Convey("Should buffer events", func() {
+			time.Sleep(time.Millisecond * 10)
+			for i := 0; i < 100; i++ {
+				So(bf.AddEvents(ctx, events), ShouldBeNil)
+				if i == 0 {
+					seen := <-sendTo.EventsChan
+					So(len(seen), ShouldEqual, 2)
+				}
+			}
+			So(bf.AddEvents(ctx, events), ShouldBeNil)
+		})
+		Convey("Should respect datapoint flags", func() {
+			checker.SetDatapointFlag(datas[0])
+			So(bf.AddDatapoints(ctx, datas), ShouldBeNil)
 			seen := <-sendTo.PointsChan
-			assert.Equal(t, 2, len(seen), "The first send should eventually come back with the first two points")
-		}
-	}
-	// Wait for more points
-	seen := <-sendTo.PointsChan
-	assert.True(t, len(seen) >= 2, fmt.Sprintf("Points should buffer: %d", len(seen)))
-	assert.Equal(t, numStats, len(bf.Datapoints()), "Checking returned stats size")
-	threadWriter.mu.Lock()
-	assert.Contains(t, buf.String(), "about to send datapoint")
-	threadWriter.mu.Unlock()
-}
-
-// TODO figure out why this test is flaky, should be > 2, but change to >= 2 so it passes
-func TestBufferedForwarderBasicEvent(t *testing.T) {
-	ctx := context.Background()
-	flagCheck := boolChecker(false)
-	checker := &dpsink.ItemFlagger{
-		CtxFlagCheck:        &flagCheck,
-		EventMetaName:       "meta_event",
-		MetricDimensionName: "sf_metric",
-	}
-	config := &Config{
-		BufferSize:         pointer.Int64(2000),
-		MaxTotalDatapoints: pointer.Int64(1000),
-		MaxTotalEvents:     pointer.Int64(1000),
-		NumDrainingThreads: pointer.Int64(1),
-		MaxDrainSize:       pointer.Int64(1000),
-		Checker:            checker,
-	}
-	sendTo := dptest.NewBasicSink()
-	buf := &bytes.Buffer{}
-	threadWriter := &threadSafeWriter{Writer: buf}
-	l := log.NewLogfmtLogger(threadWriter, log.Panic)
-	bf := NewBufferedForwarder(ctx, config, sendTo, l)
-	defer bf.Close()
-	assert.NoError(t, bf.AddEvents(ctx, []*event.Event{}))
-	time.Sleep(time.Millisecond * 5)
-	datas := []*event.Event{
-		dptest.E(),
-		dptest.E(),
-	}
-	checker.SetEventFlag(datas[0])
-	for i := 0; i < 100; i++ {
-		assert.NoError(t, bf.AddEvents(ctx, datas))
-		if i == 0 {
+			So(len(seen), ShouldEqual, 2)
+			threadWriter.mu.Lock()
+			So(buf.String(), ShouldContainSubstring, "about to send datapoint")
+			threadWriter.mu.Unlock()
+		})
+		Convey("Should respect event flags", func() {
+			checker.SetEventFlag(events[0])
+			So(bf.AddEvents(ctx, events), ShouldBeNil)
 			seen := <-sendTo.EventsChan
-			assert.Equal(t, 2, len(seen), "The first send should eventually come back with the first two events")
-		}
-	}
-	// Wait for more events
-	seen := <-sendTo.EventsChan
-	assert.True(t, len(seen) >= 2, fmt.Sprintf("Events should buffer: %d", len(seen)))
-	assert.Equal(t, numStats, len(bf.Datapoints()), "Checking returned stats size")
-	threadWriter.mu.Lock()
-	assert.Contains(t, buf.String(), "about to send event")
-	threadWriter.mu.Unlock()
+			So(len(seen), ShouldEqual, 2)
+			threadWriter.mu.Lock()
+			So(buf.String(), ShouldContainSubstring, "about to send event")
+			threadWriter.mu.Unlock()
+		})
+
+		Convey("Should respect context flags", func() {
+			threadWriter.mu.Lock()
+			flagCheck = boolChecker(true)
+			buf.Reset()
+			threadWriter.mu.Unlock()
+			So(bf.AddDatapoints(ctx, []*datapoint.Datapoint{}), ShouldBeNil)
+			threadWriter.mu.Lock()
+			So(len(buf.String()), ShouldBeGreaterThan, 0)
+			threadWriter.mu.Unlock()
+		})
+		Convey("Should respect event context flags", func() {
+			threadWriter.mu.Lock()
+			flagCheck = boolChecker(true)
+			buf.Reset()
+			threadWriter.mu.Unlock()
+			So(bf.AddEvents(ctx, []*event.Event{}), ShouldBeNil)
+			threadWriter.mu.Lock()
+			So(len(buf.String()), ShouldBeGreaterThan, 0)
+			threadWriter.mu.Unlock()
+		})
+	})
 }
 
 func TestBufferedForwarderContexts(t *testing.T) {
@@ -137,6 +152,10 @@ func TestBufferedForwarderContexts(t *testing.T) {
 		MaxTotalDatapoints: pointer.Int64(10),
 		NumDrainingThreads: pointer.Int64(2),
 		MaxDrainSize:       pointer.Int64(1000),
+		Cdim:               &log.CtxDimensions{},
+		Checker: &dpsink.ItemFlagger{
+			CtxFlagCheck: &web.HeaderCtxFlag{},
+		},
 	}
 
 	datas := []*datapoint.Datapoint{
@@ -195,6 +214,10 @@ func TestBufferedForwarderContextsEvent(t *testing.T) {
 		MaxTotalEvents:     pointer.Int64(10),
 		NumDrainingThreads: pointer.Int64(2),
 		MaxDrainSize:       pointer.Int64(1000),
+		Cdim:               &log.CtxDimensions{},
+		Checker: &dpsink.ItemFlagger{
+			CtxFlagCheck: &web.HeaderCtxFlag{},
+		},
 	}
 
 	datas := []*event.Event{
@@ -237,6 +260,10 @@ func TestBufferedForwarderMaxTotalDatapoints(t *testing.T) {
 		MaxTotalDatapoints: pointer.Int64(7),
 		NumDrainingThreads: pointer.Int64(1),
 		MaxDrainSize:       pointer.Int64(1000),
+		Cdim:               &log.CtxDimensions{},
+		Checker: &dpsink.ItemFlagger{
+			CtxFlagCheck: &web.HeaderCtxFlag{},
+		},
 	}
 	ctx := context.Background()
 	sendTo := dptest.NewBasicSink()
@@ -259,6 +286,10 @@ func TestBufferedForwarderMaxTotalEvents(t *testing.T) {
 		MaxTotalEvents:     pointer.Int64(7),
 		NumDrainingThreads: pointer.Int64(1),
 		MaxDrainSize:       pointer.Int64(1000),
+		Cdim:               &log.CtxDimensions{},
+		Checker: &dpsink.ItemFlagger{
+			CtxFlagCheck: &web.HeaderCtxFlag{},
+		},
 	}
 	ctx := context.Background()
 	sendTo := dptest.NewBasicSink()


### PR DESCRIPTION
Adds dimensions to the log that are the remote address that saw the datapoint, whenever a point is flagged as should be logged