### PR TITLE
Mercurial unused in install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,13 +6,12 @@ YUM_CMD=$(which yum)
 APT_GET_CMD=$(which apt-get)
 GO_CMD=$(which go)
 GIT_CMD=$(which git)
+set -e
 if [ ! -z "$GO_CMD" ] && [ ! -z "$GIT_CMD" ]; then
-  set -e
+  echo "Both go and git already installed, continuing"
 elif [ ! -z "$APT_GET_CMD" ]; then
-  set -e
   apt-get install -y golang git
 elif [ ! -z "$YUM_CMD" ]; then
-  set -e
   yum install -y golang git
 else
   echo "Unable to find package manager"

--- a/install.sh
+++ b/install.sh
@@ -5,15 +5,15 @@ set -x
 YUM_CMD=$(which yum)
 APT_GET_CMD=$(which apt-get)
 GO_CMD=$(which go)
-HG_CMD=$(which hg)
-if [ ! -z "$GO_CMD" ] && [ ! -z "$HG_CMD" ]; then
+GIT_CMD=$(which git)
+if [ ! -z "$GO_CMD" ] && [ ! -z "$GIT_CMD" ]; then
   set -e
 elif [ ! -z "$APT_GET_CMD" ]; then
   set -e
-  apt-get install -y golang git mercurial
+  apt-get install -y golang git
 elif [ ! -z "$YUM_CMD" ]; then
   set -e
-  yum install -y golang git mercurial
+  yum install -y golang git
 else
   echo "Unable to find package manager"
   exit 1


### PR DESCRIPTION
:information_desk_person: These changes remove the test for, and subsequent installation of, Mercurial as it isn't actually used in this script. They also consolidate the use of `set -e` and add a notification message for when both `go` and `git` are available in the user's `$PATH`.