### PR TITLE
Make getDimensionFromEmptyDims allocate less memory

### DIFF
--- a/protocol/collectd/collectd_test.go
+++ b/protocol/collectd/collectd_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/signalfx/gohelpers/workarounds"
 	"github.com/signalfx/golib/datapoint"
 	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"strconv"
 )
 
 const testDecodeCollectdBody = `[
@@ -266,5 +268,19 @@ func TestCollectdParseNameForDimensions(t *testing.T) {
 		inputDim := make(map[string]string)
 		parseNameForDimensions(inputDim, "instance", true, &test.val)
 		assert.Equal(t, test.dim, inputDim, "Dimensions not equal")
+	}
+}
+
+func BenchmarkGetDimensionFromNameEmptyDims(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		x := "ihavenodims" + strconv.Itoa(rand.Int())
+		getDimensionsFromName(&x)
+	}
+}
+
+func BenchmarkGetDimensionFromName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		x := "ihave[a=b,c=" + strconv.Itoa(rand.Int()) + "]dims"
+		getDimensionsFromName(&x)
 	}
 }

--- a/protocol/signalfx/signalfxlistener.go
+++ b/protocol/signalfx/signalfxlistener.go
@@ -268,7 +268,7 @@ func appendProperties(dp *datapoint.Datapoint, Properties map[string]ValueToSend
 	}
 }
 
-var errInvalidJSONFormat = errors.New("invalid JSON format; please see correct format at https://developers.signalfx.com/docs/datapoint\n")
+var errInvalidJSONFormat = errors.New("invalid JSON format; please see correct format at https://developers.signalfx.com/docs/datapoint")
 
 // Datapoints returns datapoints for json decoder v2
 func (decoder *JSONDecoderV2) Datapoints() []*datapoint.Datapoint {


### PR DESCRIPTION
Make getDimensionFromName allocate less memory:
```
mwp@Matthews-MacBook-Pro-3 ~/.go/src/github.com/signalfx/metricproxy (enhance)*$ benchcmp /tmp/old.txt  /tmp/newer.txt
benchmark                                    old ns/op     new ns/op     delta
BenchmarkGetDimensionFromNameEmptyDims-8     1826          1532          -16.10%
BenchmarkGetDimensionFromName-8              3679          3184          -13.45%

benchmark                                    old allocs     new allocs     delta
BenchmarkGetDimensionFromNameEmptyDims-8     4              2              -50.00%
BenchmarkGetDimensionFromName-8              9              6              -33.33%

benchmark                                    old bytes     new bytes     delta
BenchmarkGetDimensionFromNameEmptyDims-8     159           63            -60.38%
BenchmarkGetDimensionFromName-8              575           463           -19.48%
```

This is used for every plugin_instance, type_instance or host dimension passed in from collectd