### PR TITLE
Reduce calls to getDimensionsFromName by one for each datapoint

### DIFF
--- a/protocol/collectd/collectd_test.go
+++ b/protocol/collectd/collectd_test.go
@@ -266,7 +266,7 @@ func TestCollectdParseNameForDimensions(t *testing.T) {
 	}
 	for _, test := range tests {
 		inputDim := make(map[string]string)
-		parseNameForDimensions(inputDim, "instance", true, &test.val)
+		parseNameForDimensions(inputDim, "instance", &test.val)
 		assert.Equal(t, test.dim, inputDim, "Dimensions not equal")
 	}
 }
@@ -282,5 +282,22 @@ func BenchmarkGetDimensionFromName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		x := "ihave[a=b,c=" + strconv.Itoa(rand.Int()) + "]dims"
 		getDimensionsFromName(&x)
+	}
+}
+
+func BenchmarkNewDatapoint(b *testing.B) {
+	postFormat := new([]*JSONWriteFormat)
+	err := json.Unmarshal([]byte(testDecodeCollectdBody), &postFormat)
+	if err != nil {
+		b.Fail()
+	}
+	emptyMap := map[string]string{}
+	for i := 0; i < b.N; i++ {
+		NewDatapoint((*postFormat)[0], uint(0), emptyMap)
+		NewDatapoint((*postFormat)[1], uint(0), emptyMap)
+		NewDatapoint((*postFormat)[2], uint(0), emptyMap)
+		NewDatapoint((*postFormat)[3], uint(0), emptyMap)
+		NewDatapoint((*postFormat)[4], uint(0), emptyMap)
+		NewDatapoint((*postFormat)[5], uint(0), emptyMap)
 	}
 }


### PR DESCRIPTION
Reduce calls to getDimensionsFromName by one for each datapoint and makes things a bit more efficient

These numbers are after the PR  for making the  getDimensionsByName improvements and do not include them.
```
benchmark                   old ns/op     new ns/op     delta
BenchmarkNewDatapoint-8     22056         17297         -21.58%

benchmark                   old allocs     new allocs     delta
BenchmarkNewDatapoint-8     60             47             -21.67%

benchmark                   old bytes     new bytes     delta
BenchmarkNewDatapoint-8     4336          3088          -28.78%
```