### PR TITLE
Count and log late or future datapoints, spans or events if configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,10 +698,21 @@ simultaniously with each thread sending no more than 5,000 points in a single
 call.  It also turns on debug logging, which will spew a large number of log
 messages.  Only use debug logging temporarily.
 
+StatsDelay being set to 1s means every 1s we'll emit metrics out all forwarders
+about the running metric proxy.
+
+Also note that we're setting LateThreshold and FutureThreshold to 1s.  This means
+we'll count datapoints, events and spans that exceed those thresholds (if set) and
+log them up to one per second. When you've turned on as described immediately above
+you'll see metrics named late.count and future.count emitted counting each type of
+data that was late or in the future respectively.
+
 ```
 {
   "StatsDelay": "1s",
   "LogLevel": "debug",
+  "LateThreshold": "1s",
+  "FutureThreshold": "1s",
   "ListenFrom": [
     {
       "Type": "carbon",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -144,6 +144,10 @@ func TestGracefulDurations(t *testing.T) {
 		convey.So(err, convey.ShouldNotBeNil)
 		_, err = decodeConfig([]byte(`{"SilentGracefulTime":"1z"}`))
 		convey.So(err, convey.ShouldNotBeNil)
+		_, err = decodeConfig([]byte(`{"FutureThreshold":"1z"}`))
+		convey.So(err, convey.ShouldNotBeNil)
+		_, err = decodeConfig([]byte(`{"LateThreshold":"1z"}`))
+		convey.So(err, convey.ShouldNotBeNil)
 	})
 
 }

--- a/logkey/logkey.go
+++ b/logkey/logkey.go
@@ -11,6 +11,8 @@ func ignored() string {
 var (
 	// Filename is a system file name
 	Filename = log.Key("filename")
+	// Delta is the diff between two things, generally time
+	Delta = log.Key("delta")
 	// Dir is a directory
 	Dir = log.Key("directory")
 	// Struct is the name of a go struct

--- a/main.go
+++ b/main.go
@@ -432,7 +432,11 @@ func (p *proxy) run(ctx context.Context) error {
 		DatapointSinks: dpSinks,
 		EventSinks:     eSinks,
 		TraceSinks:     tSinks,
+		Logger:         log.NewOnePerSecond(logger),
+		LateDuration:   loadedConfig.LateThresholdDuration,
+		FutureDuration: loadedConfig.FutureThresholdDuration,
 	}
+	scheduler.AddCallback(dmux)
 
 	multiplexer := signalfx.FromChain(dmux, signalfx.NextWrap(signalfx.UnifyNextSinkWrap(&p.debugSink)))
 

--- a/protocol/demultiplexer/demultiplexer.go
+++ b/protocol/demultiplexer/demultiplexer.go
@@ -6,7 +6,12 @@ import (
 	"github.com/signalfx/golib/datapoint/dpsink"
 	"github.com/signalfx/golib/errors"
 	"github.com/signalfx/golib/event"
+	"github.com/signalfx/golib/log"
+	"github.com/signalfx/golib/sfxclient"
 	"github.com/signalfx/golib/trace"
+	"github.com/signalfx/metricproxy/logkey"
+	"sync/atomic"
+	"time"
 )
 
 // Demultiplexer is a sink that forwards points it sees to multiple sinks
@@ -14,6 +19,17 @@ type Demultiplexer struct {
 	DatapointSinks []dpsink.DSink
 	EventSinks     []dpsink.ESink
 	TraceSinks     []trace.Sink
+	Logger         log.Logger
+	LateDuration   *time.Duration
+	FutureDuration *time.Duration
+	stats          struct {
+		lateDps      int64
+		futureDps    int64
+		lateEvents   int64
+		futureEvents int64
+		lateSpans    int64
+		futureSpans  int64
+	}
 }
 
 var _ dpsink.Sink = &Demultiplexer{}
@@ -24,6 +40,7 @@ func (streamer *Demultiplexer) AddDatapoints(ctx context.Context, points []*data
 	if len(points) == 0 {
 		return nil
 	}
+	streamer.handleLateOrFuturePoints(points)
 	var errs []error
 	for _, sendTo := range streamer.DatapointSinks {
 		if err := sendTo.AddDatapoints(ctx, points); err != nil {
@@ -33,31 +50,103 @@ func (streamer *Demultiplexer) AddDatapoints(ctx context.Context, points []*data
 	return errors.NewMultiErr(errs)
 }
 
+func (streamer *Demultiplexer) handleLateOrFuturePoints(points []*datapoint.Datapoint) {
+	if streamer.FutureDuration != nil || streamer.LateDuration != nil {
+		now := time.Now()
+
+		for _, d := range points {
+			if streamer.FutureDuration != nil && d.Timestamp.After(now.Add(*streamer.FutureDuration)) {
+				atomic.AddInt64(&streamer.stats.futureDps, 1)
+				streamer.Logger.Log(logkey.Name, d.String(), logkey.Delta, d.Timestamp.Sub(now), "datapoint received too far into the future")
+			} else if streamer.LateDuration != nil && d.Timestamp.Before(now.Add(-*streamer.LateDuration)) {
+				atomic.AddInt64(&streamer.stats.lateDps, 1)
+				streamer.Logger.Log(logkey.Name, d.String(), logkey.Delta, now.Sub(d.Timestamp), "datapoint received too far into the past")
+			}
+		}
+	}
+}
+
 // AddEvents forwards all events to each sendTo sink.  Returns the error message of the last
 // sink to have an error.
-func (streamer *Demultiplexer) AddEvents(ctx context.Context, points []*event.Event) error {
-	if len(points) == 0 {
+func (streamer *Demultiplexer) AddEvents(ctx context.Context, events []*event.Event) error {
+	if len(events) == 0 {
 		return nil
 	}
+	streamer.handleLateOrFutureEvents(events)
 	var errs []error
 	for _, sendTo := range streamer.EventSinks {
-		if err := sendTo.AddEvents(ctx, points); err != nil {
+		if err := sendTo.AddEvents(ctx, events); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.NewMultiErr(errs)
 }
 
+func (streamer *Demultiplexer) handleLateOrFutureEvents(events []*event.Event) {
+	if streamer.FutureDuration != nil || streamer.LateDuration != nil {
+		now := time.Now()
+
+		for _, d := range events {
+			if streamer.FutureDuration != nil && d.Timestamp.After(now.Add(*streamer.FutureDuration)) {
+				atomic.AddInt64(&streamer.stats.futureEvents, 1)
+				streamer.Logger.Log(logkey.Name, d.String(), logkey.Delta, d.Timestamp.Sub(now), "event received too far into the future")
+			} else if streamer.LateDuration != nil && d.Timestamp.Before(now.Add(-*streamer.LateDuration)) {
+				atomic.AddInt64(&streamer.stats.lateEvents, 1)
+				streamer.Logger.Log(logkey.Name, d.String(), logkey.Delta, now.Sub(d.Timestamp), "event received too far into the past")
+			}
+		}
+	}
+}
+
 // AddSpans forwards all traces to each sentTo sink. Returns the error of the last sink to have an error.
-func (streamer *Demultiplexer) AddSpans(ctx context.Context, traces []*trace.Span) error {
-	if len(traces) == 0 {
+func (streamer *Demultiplexer) AddSpans(ctx context.Context, spans []*trace.Span) error {
+	if len(spans) == 0 {
 		return nil
 	}
+	streamer.handleLateOrFutureSpans(spans)
 	var errs []error
 	for _, sendTo := range streamer.TraceSinks {
-		if err := sendTo.AddSpans(ctx, traces); err != nil {
+		if err := sendTo.AddSpans(ctx, spans); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.NewMultiErr(errs)
+}
+
+func (streamer *Demultiplexer) handleLateOrFutureSpans(spans []*trace.Span) {
+	if streamer.FutureDuration != nil || streamer.LateDuration != nil {
+		now := time.Now()
+		for _, d := range spans {
+			//now.Sub(time.Unix(0, int64(*d.Timestamp)*int64(time.Microsecond)))
+			if streamer.FutureDuration != nil && time.Unix(0, int64(*d.Timestamp)*int64(time.Microsecond)).After(now.Add(*streamer.FutureDuration)) {
+
+				atomic.AddInt64(&streamer.stats.futureSpans, 1)
+				streamer.Logger.Log(logkey.Name, d.ID, logkey.Delta, time.Unix(0, int64(*d.Timestamp)*int64(time.Microsecond)).Sub(now), "trace received too far into the future")
+			} else if streamer.LateDuration != nil && time.Unix(0, int64(*d.Timestamp)*int64(time.Microsecond)).Before(now.Add(-*streamer.LateDuration)) {
+
+				atomic.AddInt64(&streamer.stats.lateSpans, 1)
+				streamer.Logger.Log(logkey.Name, d.ID, logkey.Delta, now.Sub(time.Unix(0, int64(*d.Timestamp)*int64(time.Microsecond))), "trace received too far into the past")
+			}
+		}
+	}
+}
+
+// Datapoints adheres to the sfxclient.Collector interface
+func (streamer *Demultiplexer) Datapoints() []*datapoint.Datapoint {
+	var dps []*datapoint.Datapoint
+	if streamer.FutureDuration != nil {
+		dps = append(dps, []*datapoint.Datapoint{
+			sfxclient.Cumulative("future.count", map[string]string{"type": "datapoint"}, atomic.LoadInt64(&streamer.stats.futureDps)),
+			sfxclient.Cumulative("future.count", map[string]string{"type": "event"}, atomic.LoadInt64(&streamer.stats.futureEvents)),
+			sfxclient.Cumulative("future.count", map[string]string{"type": "spans"}, atomic.LoadInt64(&streamer.stats.futureSpans)),
+		}...)
+	}
+	if streamer.LateDuration != nil {
+		dps = append(dps, []*datapoint.Datapoint{
+			sfxclient.Cumulative("late.count", map[string]string{"type": "datapoint"}, atomic.LoadInt64(&streamer.stats.lateDps)),
+			sfxclient.Cumulative("late.count", map[string]string{"type": "event"}, atomic.LoadInt64(&streamer.stats.lateEvents)),
+			sfxclient.Cumulative("late.count", map[string]string{"type": "spans"}, atomic.LoadInt64(&streamer.stats.lateSpans)),
+		}...)
+	}
+	return dps
 }

--- a/protocol/demultiplexer/demultiplexer_test.go
+++ b/protocol/demultiplexer/demultiplexer_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/signalfx/golib/datapoint/dpsink"
 	"github.com/signalfx/golib/datapoint/dptest"
 	"github.com/signalfx/golib/event"
+	"github.com/signalfx/golib/log"
+	"github.com/signalfx/golib/pointer"
 	"github.com/signalfx/golib/trace"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,19 +21,41 @@ func TestNew(t *testing.T) {
 	sendTo1 := dptest.NewBasicSink()
 	sendTo2 := dptest.NewBasicSink()
 	sendTo3 := dptest.NewBasicSink()
+	c := &log.Counter{}
+	second := 100 * time.Microsecond
 	demux := Demultiplexer{
 		DatapointSinks: []dpsink.DSink{sendTo1},
 		EventSinks:     []dpsink.ESink{sendTo2},
 		TraceSinks:     []trace.Sink{sendTo3},
+		Logger:         c,
+		LateDuration:   &second,
+		FutureDuration: &second,
 	}
 
+	late := time.Now().Add(-time.Second)
+	future := time.Now().Add(time.Second)
 	pts := []*datapoint.Datapoint{dptest.DP(), dptest.DP()}
+	pts[0].Timestamp = late
+	pts[1].Timestamp = future
 	es := []*event.Event{dptest.E(), dptest.E()}
-	traces := []*trace.Span{{}}
+	es[0].Timestamp = late
+	es[1].Timestamp = future
+	traces := []*trace.Span{{Timestamp: pointer.Float64(float64(late.UnixNano() / 1000))}, {Timestamp: pointer.Float64(float64(future.UnixNano() / 1000))}}
 	ctx2, cancelFunc := context.WithTimeout(ctx, time.Millisecond)
 	assert.Error(t, demux.AddDatapoints(ctx2, pts))
 	assert.Error(t, demux.AddEvents(ctx2, es))
 	assert.Error(t, demux.AddSpans(ctx2, traces))
+	assert.Error(t, demux.AddDatapoints(ctx2, pts[1:]))
+	assert.Error(t, demux.AddEvents(ctx2, es[1:]))
+	assert.Error(t, demux.AddSpans(ctx2, traces[1:]))
+	assert.Equal(t, c.Count, int64(9))
+	assert.Equal(t, demux.stats.futureDps, int64(2))
+	assert.Equal(t, demux.stats.lateDps, int64(1))
+	assert.Equal(t, demux.stats.futureEvents, int64(2))
+	assert.Equal(t, demux.stats.lateEvents, int64(1))
+	assert.Equal(t, demux.stats.futureSpans, int64(2))
+	assert.Equal(t, demux.stats.lateSpans, int64(1))
+	assert.Equal(t, len(demux.Datapoints()), 6)
 	assert.NoError(t, demux.AddDatapoints(context.Background(), []*datapoint.Datapoint{}))
 	assert.NoError(t, demux.AddEvents(context.Background(), []*event.Event{}))
 	assert.NoError(t, demux.AddSpans(context.Background(), []*trace.Span{}))


### PR DESCRIPTION
Logging is only done at most once per second.