### PR TITLE
Update example sfdbproxy.conf to use the more correct type for SignalFx

### DIFF
--- a/exampleSfdbproxy.conf
+++ b/exampleSfdbproxy.conf
@@ -3,7 +3,7 @@
         {
             "DefaultAuthToken": "___AUTH_TOKEN___", 
             "Name": "testproxy", 
-            "type": "signalfx-json"
+            "type": "signalfx"
         }, 
         {
             "Filename": "/tmp/filewrite.csv", 


### PR DESCRIPTION
Update example sfdbproxy.conf to use the more correct type for SignalFx.