### PR TITLE
override etcd cluster configurations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,7 +98,6 @@ type ProxyConfig struct {
 	LateThresholdDuration         *time.Duration `json:"-"`
 	FutureThresholdDuration       *time.Duration `json:"-"`
 	ClusterOperation              *string        `json:",omitempty"`
-	ClusterMemberName             *string        `json:",omitempty"`
 	ClusterDataDir                *string        `json:",omitempty"`
 	TargetClusterAddresses        []string       `json:",omitempty"`
 	AdvertisePeerAddress          *string        `json:",omitempty"`
@@ -129,7 +128,6 @@ var DefaultProxyConfig = &ProxyConfig{
 	UnhealthyMemberTTL:            pointer.Duration(time.Second * 5),
 	RemoveMemberTimeout:           pointer.Duration(time.Second),
 	ClusterDataDir:                pointer.String("./etcd-data"),
-	ClusterMemberName:             pointer.String(""),
 	ClusterOperation:              pointer.String(""),
 	TargetClusterAddresses:        []string{},
 }

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func (mgr *etcdManager) setup(conf *config.ProxyConfig) {
 		mgr.operation = getStringEnvVar("SFX_CLUSTER_OPERATION", *conf.ClusterOperation)
 	}
 
-	mgr.targetCluster = getCommaSeparatedStringEnvVar("SFX_TARGET_CLUSTER_ADDRESS", conf.TargetClusterAddresses)
+	mgr.targetCluster = getCommaSeparatedStringEnvVar("SFX_TARGET_CLUSTER_ADDRESSES", conf.TargetClusterAddresses)
 }
 
 func (mgr *etcdManager) start() (err error) {


### PR DESCRIPTION
* allow cluster configurations to be overridden by environment variables
* use server name instead of ClusterMemberName